### PR TITLE
DM-49755: Add do-not-upload classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.13"


### PR DESCRIPTION
Add `Private :: Do Not Upload` to the classifiers so that PyPI will reject this package if it is accidentally uploaded. This a service and the intended release artifact is a Docker container.