### PR TITLE
DM-49755: Clean up unnecessary apt-get invocations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",
-    "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Private :: Do Not Upload",

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -28,7 +28,3 @@ apt-get -y upgrade
 
 # Example of installing a new package, without unnecessary packages:
 apt-get -y install --no-install-recommends git
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -21,14 +21,7 @@ set -x
 # feedback:
 export DEBIAN_FRONTEND=noninteractive
 
-# Update the package listing, so we know what packages exist:
-apt-get update
-
 # Install build-essential because sometimes Python dependencies need to build
 # C modules, particularly when upgrading to newer Python versions.  libffi-dev
 # is sometimes needed to build cffi (a cryptography dependency).
 apt-get -y install --no-install-recommends build-essential libffi-dev
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Stop cleaning up after apt-get, since we now use a cache file system for its data files. Don't re-run apt-get update when installing dependency packages, since we should continue to use the data cached when updating the base packages.