### PR TITLE
DM-49755: Do not include query info in error messages

### DIFF
--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -274,30 +274,6 @@ class JobQueryInfo(BaseModel):
             result.end_time = status.last_update
         return result
 
-    @classmethod
-    def for_error(cls, start: datetime) -> Self:
-        """Return a minimal query status used when reporting an error.
-
-        This is used when there's some failure at the API level that
-        interferes with getting the full status of the job.
-
-        Parameters
-        ----------
-        start
-            When the query was started.
-
-        Returns
-        -------
-        JobQueryInfo
-            Minimal query information suitable for an error status message.
-        """
-        return cls(
-            start_time=start,
-            end_time=datetime.now(tz=UTC),
-            total_chunks=0,
-            completed_chunks=0,
-        )
-
 
 class JobResultInfo(BaseModel):
     """Result of a query."""
@@ -394,9 +370,9 @@ class JobStatus(BaseModel):
     ]
 
     query_info: Annotated[
-        JobQueryInfo,
+        JobQueryInfo | None,
         Field(title="Query information", serialization_alias="queryInfo"),
-    ]
+    ] = None
 
     result_info: Annotated[
         JobResultInfo | None,

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -52,7 +52,6 @@ class QueryService:
             Initial status of the job.
         """
         metadata = job.to_job_metadata()
-        start = datetime.now(tz=UTC)
         query_id = None
         status = None
 
@@ -70,7 +69,6 @@ class QueryService:
                 execution_id=str(query_id) if query_id else None,
                 timestamp=datetime.now(tz=UTC),
                 status=ExecutionPhase.ERROR,
-                query_info=JobQueryInfo.for_error(start),
                 error=e.to_job_error(),
                 metadata=metadata,
             )

--- a/tests/models/kafka_test.py
+++ b/tests/models/kafka_test.py
@@ -100,12 +100,6 @@ def test_job_status() -> None:
         execution_id="123",
         timestamp=now,
         status=ExecutionPhase.ERROR,
-        query_info=JobQueryInfo(
-            start_time=start,
-            end_time=end,
-            total_chunks=3,
-            completed_chunks=1,
-        ),
         error=JobError(
             code=JobErrorCode.backend_error, message="Syntax Error at line 1"
         ),
@@ -118,12 +112,6 @@ def test_job_status() -> None:
         "executionID": "123",
         "timestamp": int(now.timestamp() * 1000),
         "status": "ERROR",
-        "queryInfo": {
-            "startTime": int(start.timestamp() * 1000),
-            "endTime": int(end.timestamp() * 1000),
-            "totalChunks": 3,
-            "completedChunks": 1,
-        },
         "errorInfo": {
             "errorCode": "backend_error",
             "errorMessage": "Syntax Error at line 1",

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -77,7 +77,8 @@ def read_test_job_status(
     result = JobStatus.model_validate(read_test_json(filename))
     if mock_timestamps:
         result.timestamp = ANY
-        result.query_info.start_time = ANY
-        if result.query_info.end_time:
-            result.query_info.end_time = ANY
+        if result.query_info:
+            result.query_info.start_time = ANY
+            if result.query_info.end_time:
+                result.query_info.end_time = ANY
     return result


### PR DESCRIPTION
When sending an error response because of a low-level protocol error talking to Qserv, do not include query info in the message rather than including fake query info. By definition we were unable to contact Qserv to get actual information, and the schema allows this element to be omitted.