### PR TITLE
DM-49755: Update Kafka models for recent changes

### DIFF
--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -55,7 +55,7 @@ class AsyncQueryPhase(StrEnum):
                 return ExecutionPhase.ERROR
             case "ABORTED":
                 return ExecutionPhase.ABORTED
-            case _:
+            case _:  # pragma: no cover
                 raise ValueError(f"Unknown phase {self.value}")
 
 

--- a/src/qservkafka/models/votable.py
+++ b/src/qservkafka/models/votable.py
@@ -1,0 +1,53 @@
+"""Models for VOTables."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any
+
+from pydantic import BaseModel, Field, PlainValidator
+
+__all__ = [
+    "VOTableArraySize",
+    "VOTablePrimitive",
+    "VOTableSize",
+]
+
+
+class VOTableSize(BaseModel):
+    """Parsed VOTable array size."""
+
+    limit: Annotated[int | None, Field(title="Maximum length")]
+
+    variable: Annotated[bool, Field(title="Whether length can vary")]
+
+
+def _validate_array_size(arraysize: Any) -> VOTableSize:
+    """Verify that a VOTable arraysize is in a valid format."""
+    if isinstance(arraysize, VOTableSize):
+        return arraysize
+    if not isinstance(arraysize, str):
+        msg = f"Invalid arraysize type {type(arraysize).__name__}"
+        raise ValueError(msg)  # noqa: TRY004 (Pydantic requirement)
+    variable = False
+    if arraysize.endswith("*"):
+        variable = True
+        arraysize = arraysize.removesuffix("*")
+    limit = int(arraysize) if arraysize else None
+    return VOTableSize(limit=limit, variable=variable)
+
+
+type VOTableArraySize = Annotated[
+    VOTableSize, PlainValidator(_validate_array_size)
+]
+
+
+class VOTablePrimitive(StrEnum):
+    """VOTable primitive types supported by the Qserv Kafka bridge."""
+
+    boolean = "boolean"
+    char = "char"
+    double = "double"
+    float = "float"
+    int = "int"
+    long = "long"

--- a/tests/data/jobs/simple.json
+++ b/tests/data/jobs/simple.json
@@ -5,11 +5,20 @@
   "ownerID": "username",
   "resultDestination": "https://gcs.example.com/upload",
   "resultFormat": {
-    "type": "votable",
-    "serialization": "BINARY2",
+    "format": {
+      "type": "votable",
+      "serialization": "BINARY2"
+    },
     "envelope": {
       "header": "<VOTable xmlns=\"http://www.ivoa.net/xml/VOTable/v1.3\" version=\"1.3\"><RESOURCE type=\"results\"><TABLE><FIELD ID=\"col_0\" arraysize=\"*\" datatype=\"char\" name=\"col1\"/>",
       "footer": "</TABLE></RESOURCE></VOTable>"
-    }
+    },
+    "columnTypes": [
+      {
+        "name": "col_0",
+        "datatype": "char",
+        "arraysize": "*"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Include the column type information in the `JobRun` model, which will be used for output serialization. Rework how the output format is represented to match recent changes in SQR-097. Include the `resultLocation` attribute in the `JobRun` model so that it can be included in the output for a completed job.