### PR TITLE
DM-49755: Start tracking query state

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -10,6 +10,7 @@ from structlog.stdlib import BoundLogger
 
 from .services.query import QueryService
 from .storage.rest import QservRestClient
+from .storage.state import QueryStateStore
 
 __all__ = ["Factory", "ProcessContext"]
 
@@ -75,7 +76,8 @@ class Factory:
             New service to start queries.
         """
         rest_store = QservRestClient(self._context.http_client)
-        return QueryService(rest_store, self._logger)
+        state_store = QueryStateStore(self._logger)
+        return QueryService(rest_store, state_store, self._logger)
 
     def set_logger(self, logger: BoundLogger) -> None:
         """Replace the internal logger.

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -1,0 +1,19 @@
+"""Models for tracking the state of running queries."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from .kafka import JobRun
+
+__all__ = ["Query"]
+
+
+class Query(BaseModel):
+    """Represents a running Qserv query."""
+
+    query_id: Annotated[int, Field(title="Qserv ID of query")]
+
+    job: Annotated[JobRun, Field(title="Full job request")]

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -1,0 +1,80 @@
+"""State tracking for queries in progress."""
+
+from __future__ import annotations
+
+from structlog.stdlib import BoundLogger
+
+from ..models.kafka import JobRun
+from ..models.state import Query
+
+__all__ = ["QueryStateStore"]
+
+
+class QueryStateStore:
+    """Tracks Qserv queries in progress.
+
+    Currently, this uses a simple in-memory store that is wiped whenever the
+    Qserv Kafka bridge is restarted. Eventually, it will use Redis so that the
+    service can recover from restarts.
+    """
+
+    def __init__(self, logger: BoundLogger) -> None:
+        self._logger = logger
+
+        # Map from Qserv query ID to query metadata.
+        self._queries: dict[int, Query] = {}
+
+    def add_query(self, query_id: int, job: JobRun) -> None:
+        """Add a record for a newly-created query.
+
+        Parameters
+        ----------
+        query_id
+            Qserv query ID.
+        job
+            Original job request.
+        """
+        if query_id in self._queries:
+            msg = "Duplicate query ID, replacing old query record"
+            self._logger.error(msg, query_id=query_id)
+        self._queries[query_id] = Query(query_id=query_id, job=job)
+
+    def delete_query(self, query_id: int) -> None:
+        """Delete a query from storage.
+
+        Should be called after the query results have been stored (if
+        applicable) and just before sending the Kafka message giving the
+        result.
+
+        Parameters
+        ----------
+        query_id
+            Qserv query ID.
+        """
+        if query_id in self._queries:
+            del self._queries[query_id]
+
+    def get_active_queries(self) -> set[int]:
+        """Get the IDs of all active queries.
+
+        Returns
+        -------
+        set of int
+            All queries we believe are currently active.
+        """
+        return set(self._queries.keys())
+
+    def get_query(self, query_id: int) -> Query | None:
+        """Get the original job request for a given query.
+
+        Parameters
+        ----------
+        query_id
+            Qserv query ID.
+
+        Returns
+        -------
+        job or None
+            Original job request, or `None` if no such job was found.
+        """
+        return self._queries.get(query_id)


### PR DESCRIPTION
For now, only track query state in memory. This will be used when polling Qserv for current running queries so that we know when queries have finished and what query results to retrieve.