### PR TITLE
DM-49755: Log reply from Qserv REST API at debug level

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -75,7 +75,7 @@ class Factory:
         QueryService
             New service to start queries.
         """
-        rest_store = QservRestClient(self._context.http_client)
+        rest_store = QservRestClient(self._context.http_client, self._logger)
         state_store = QueryStateStore(self._logger)
         return QueryService(rest_store, state_store, self._logger)
 


### PR DESCRIPTION
Log all replies that we get from the Qserv REST API at debug level. This will be useful once we start integration testing.