### PR TITLE
DM-49993: Fix Docker start command path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,15 +55,15 @@ RUN useradd --create-home appuser
 # Copy the virtualenv.
 COPY --from=install-image /app /app
 
-# Make sure we use the virtualenv.
-WORKDIR /app
-ENV PATH="/opt/venv/bin:$PATH"
-
 # Switch to the non-root user.
 USER appuser
 
 # Expose the port.
 EXPOSE 8080
+
+# Make sure we use the virtualenv.
+WORKDIR /app
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Run the application.
 CMD ["uvicorn", "qservkafka.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
Fix the PATH used by the Docker start command so that the virtual environment is on the PATH.