### PR TITLE
DM-49993: Lowercase the columns from processlist

### DIFF
--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -34,11 +34,11 @@ API_VERSION = 39
 
 _QUERY_LIST_SQL = """
     SELECT
-      id,
-      submitted,
-      updated,
-      chunks,
-      chunks_comp
+      ID AS id,
+      SUBMITTED AS submitted,
+      UPDATED AS updated,
+      CHUNKS AS chunks,
+      CHUNKS_COMP as chunks_comp
     FROM information_schema.processlist
 """
 """SQL query to get a list of running queries.


### PR DESCRIPTION
Qserv really does appear to return the columns of the process list query in all uppercase, and then accessing them by lowercase attribute name fails. Rename them in the query, since making them uppercase in the mock creates a cascade of other problems.