### PR TITLE
DM-50095: Add TLS configuration for MySQL connections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,6 @@ new_fragment_template = "file:changelog.d/_template.md.jinja"
 skip_fragments = "_template.md.jinja"
 
 [tool.setuptools_scm]
+
+[tool.uv.sources]
+safir = { git = "https://github.com/lsst-sqre/safir", branch = "tickets/DM-50095", subdirectory = "safir" }

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -65,8 +65,9 @@ class Config(BaseSettings):
     @classmethod
     def _validate_qserv_database_url(cls, v: MySQLDsn) -> MySQLDsn:
         """Ensure that the Qserv DSN uses a compatible dialect."""
-        if v.scheme != "mysql+asyncmy":
-            raise ValueError("Only mysql+asyncmy DSN schemes are supported")
+        if v.scheme not in ("mysql", "mysql+asyncmy"):
+            msg = "Only mysql or mysql+asyncmy DSN schemes are supported"
+            raise ValueError(msg)
         return v
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.11" },
     { name = "pydantic-settings", specifier = ">=2.8" },
-    { name = "safir", extras = ["db"], specifier = ">=9.1.1" },
+    { name = "safir", extras = ["db"], git = "https://github.com/lsst-sqre/safir?subdirectory=safir&branch=tickets%2FDM-50095" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
     { name = "vo-models", specifier = ">=0.4" },
 ]
@@ -1209,8 +1209,8 @@ wheels = [
 
 [[package]]
 name = "safir"
-version = "10.0.0"
-source = { registry = "https://pypi.org/simple" }
+version = "10.0.1.dev6+g14b7274"
+source = { git = "https://github.com/lsst-sqre/safir?subdirectory=safir&branch=tickets%2FDM-50095#14b7274e7e11b534348549b75ccf7229091736de" }
 dependencies = [
     { name = "aiokafka" },
     { name = "click" },
@@ -1228,10 +1228,6 @@ dependencies = [
     { name = "sentry-sdk" },
     { name = "starlette" },
     { name = "structlog" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/b8/c85eff31ef738a239409709460c3162f29a98df3fd00de49c1504f74bbe0/safir-10.0.0.tar.gz", hash = "sha256:11bdf7a129b445da9395008a4fe73bdf43da3c3546f7183d9974a969f2f132de", size = 181007 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/84/a4c33f3a7e4abea1e15d5c94d3786558d730cbfa873d7d4ef27a0ab2c40a/safir-10.0.0-py3-none-any.whl", hash = "sha256:8bbff75a11b87c140214e6f5671852604867c56acf2aa30cd3a14347cbf4e7bc", size = 153146 },
 ]
 
 [package.optional-dependencies]
@@ -1272,15 +1268,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.25.1"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/2f/a0f732270cc7c1834f5ec45539aec87c360d5483a8bd788217a9102ccfbd/sentry_sdk-2.25.1.tar.gz", hash = "sha256:f9041b7054a7cf12d41eadabe6458ce7c6d6eea7a97cfe1b760b6692e9562cf0", size = 322190 }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e2/f8ebb2086046d89cb692f12cc7f9d84e02669d19e263f9b0347553ac6e8c/sentry_sdk-2.26.0.tar.gz", hash = "sha256:88643459716dd0c6e412e5141fcc94ce3b5725e4b6b312210b91332b3b46a0e2", size = 322738 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/b6/84049ab0967affbc7cc7590d86ae0170c1b494edb69df8786707100420e5/sentry_sdk-2.25.1-py2.py3-none-any.whl", hash = "sha256:60b016d0772789454dc55a284a6a44212044d4a16d9f8448725effee97aaf7f6", size = 339851 },
+    { url = "https://files.pythonhosted.org/packages/dd/da/195136b1113e5bc34f31ba04a345bc15c1e66a4eacfc1b317de111abe8c5/sentry_sdk-2.26.0-py2.py3-none-any.whl", hash = "sha256:82496fc359296dac57ec923300b18cc1f14a1279c1e7108d46d35dbb4cf8f5f8", size = 340184 },
 ]
 
 [[package]]
@@ -1329,14 +1325,14 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "0.46.1"
+version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102 }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995 },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
 ]
 
 [[package]]
@@ -1479,15 +1475,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.34.0"
+version = "0.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
+sdist = { url = "https://files.pythonhosted.org/packages/86/37/dd92f1f9cedb5eaf74d9999044306e06abe65344ff197864175dbbd91871/uvicorn-0.34.1.tar.gz", hash = "sha256:af981725fc4b7ffc5cb3b0e9eda6258a90c4b52cb2a83ce567ae0a7ae1757afc", size = 76755 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
+    { url = "https://files.pythonhosted.org/packages/5f/38/a5801450940a858c102a7ad9e6150146a25406a119851c993148d56ab041/uvicorn-0.34.1-py3-none-any.whl", hash = "sha256:984c3a8c7ca18ebaad15995ee7401179212c59521e67bfc390c07fa2b8d2e065", size = 62404 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Configure a TLS context for MySQL connections and pass it as an additional connection argument to asyncmy. Disable certificate verification because Qserv uses a self-signed certificate.

Use the unreleased version of Safir for now until `connect_args` support has been merged.