### PR TITLE
DM-50188: Reject job requests using arraysize

### DIFF
--- a/tests/data/jobs/arraysize.json
+++ b/tests/data/jobs/arraysize.json
@@ -1,0 +1,29 @@
+{
+  "query": "SELECT TOP 10 * FROM table",
+  "database": "dp1",
+  "jobID": "uws123",
+  "ownerID": "username",
+  "resultDestination": "https://gcs.example.com/upload",
+  "resultFormat": {
+    "format": {
+      "type": "votable",
+      "serialization": "BINARY2"
+    },
+    "envelope": {
+      "header": "<VOTable xmlns=\"http://www.ivoa.net/xml/VOTable/v1.3\" version=\"1.3\"><RESOURCE type=\"results\"><TABLE><FIELD ID=\"col_0\" arraysize=\"*\" datatype=\"char\" name=\"col1\"/>",
+      "footer": "</TABLE></RESOURCE></VOTable>"
+    },
+    "columnTypes": [
+      {
+        "name": "col_0",
+        "datatype": "char",
+        "arraysize": "*"
+      },
+      {
+        "name": "col_1",
+        "datatype": "long",
+        "arraysize": "10"
+      }
+    ]
+  }
+}

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -195,3 +195,20 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.timestamp = ANY
     assert expected.error
     assert status == expected
+
+    job = read_test_job_run("jobs/arraysize")
+    status = await query_service.start_query(job)
+    expected = JobStatus(
+        job_id=job.job_id,
+        execution_id=None,
+        timestamp=now,
+        status=ExecutionPhase.ERROR,
+        error=JobError(
+            code=JobErrorCode.invalid_request,
+            message="arraysize only supported for char fields",
+        ),
+        metadata=job.to_job_metadata(),
+    )
+    expected.timestamp = ANY
+    assert expected.error
+    assert status == expected


### PR DESCRIPTION
The `BINARY2` encoder only supports arraysize for char fields. Reject jobs with an immediate error if arraysize is used for any other primitive VOTable type.