### PR TITLE
DM-50225: Move Kafka router into a separate module

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -64,7 +64,7 @@ class ProcessContext:
         logger = get_logger("qservkafka")
 
         # Qserv currently uses a self-signed certificate.
-        http_client = AsyncClient(verify=False)  # noqa: S501
+        http_client = AsyncClient(timeout=30, verify=False)  # noqa: S501
 
         # Qserv uses a self-signed certificate with no known certificate
         # chain. We do not use TLS to validate the identity of the server.

--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -22,7 +22,9 @@ __all__ = ["kafka_router", "publisher"]
 
 
 @kafka_router.subscriber(
-    config.job_run_topic, group_id=config.consumer_group_id
+    config.job_run_topic,
+    auto_offset_reset="earliest",
+    group_id=config.consumer_group_id,
 )
 @publisher
 async def job_run(

--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -110,4 +110,13 @@ class AsyncSubmitRequest(BaseModel):
 class AsyncSubmitResponse(BaseResponse):
     """Response from creating an async job."""
 
-    query_id: Annotated[int, Field(title="Query ID")]
+    model_config = ConfigDict(validate_by_name=True)
+
+    query_id: Annotated[
+        int,
+        Field(
+            title="Query ID",
+            serialization_alias="queryId",
+            validation_alias="queryId",
+        ),
+    ]


### PR DESCRIPTION
When the Kafka router was moved into the factory so that it could be used by background tasks, this cased the Kafka handler module to never be imported, so no handler functions were ever registered. Use the same pattern as Ook and move the Kafka router into its own module to avoid circular dependencies.