### PR TITLE
DM-50277: Move Kafka router into a separate module

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -6,7 +6,6 @@ import ssl
 from dataclasses import dataclass
 from typing import Self
 
-from faststream.kafka.fastapi import KafkaRouter
 from httpx import AsyncClient
 from safir.database import create_async_session, create_database_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
@@ -15,18 +14,14 @@ from structlog.stdlib import BoundLogger
 
 from .background import BackgroundTaskManager
 from .config import config
+from .kafkarouters import kafka_router
 from .services.monitor import QueryMonitor
 from .services.query import QueryService
 from .storage.qserv import QservClient
 from .storage.state import QueryStateStore
 from .storage.votable import VOTableWriter
 
-kafka_router = KafkaRouter(
-    **config.kafka.to_faststream_params(), logger=get_logger("qservkafka")
-)
-"""Faststream router for incoming Kafka requests."""
-
-__all__ = ["Factory", "ProcessContext", "kafka_router"]
+__all__ = ["Factory", "ProcessContext"]
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -1,4 +1,10 @@
-"""Kafka router and consumers."""
+"""Kafka router and consumers.
+
+The `kafka_router` symbol must be imported from this module, not from its true
+source at `~qservkafka.kafkarouters.kafka_router`, to ensure that the router
+is properly configured with its subscribers and publishers. Otherwise, the
+router will have no subscribers and no publishers and will thus do nothing.
+"""
 
 from typing import Annotated
 
@@ -6,7 +12,7 @@ from fastapi import Depends
 
 from ..config import config
 from ..dependencies.context import ConsumerContext, context_dependency
-from ..factory import kafka_router
+from ..kafkarouters import kafka_router
 from ..models.kafka import JobRun, JobStatus
 
 publisher = kafka_router.publisher(config.job_status_topic)

--- a/src/qservkafka/kafkarouters.py
+++ b/src/qservkafka/kafkarouters.py
@@ -1,0 +1,22 @@
+"""The FastStream Kafka router.
+
+Notes
+-----
+This module holds kafka_router in a separate module to avoid circular imports
+with the `~qservkafka.dependencies.context.context_dependency`.
+"""
+
+from __future__ import annotations
+
+from faststream.kafka.fastapi import KafkaRouter
+from structlog import get_logger
+
+from .config import config
+
+__all__ = ["kafka_router"]
+
+
+kafka_router = KafkaRouter(
+    **config.kafka.to_faststream_params(), logger=get_logger("qservkafka")
+)
+"""Faststream router for incoming Kafka requests."""

--- a/src/qservkafka/main.py
+++ b/src/qservkafka/main.py
@@ -17,8 +17,8 @@ from structlog import get_logger
 
 from .config import config
 from .dependencies.context import context_dependency
-from .factory import kafka_router
 from .handlers.internal import internal_router
+from .handlers.kafka import kafka_router
 
 __all__ = ["app"]
 


### PR DESCRIPTION
When the Kafka router was moved into the factory so that it could be used by background tasks, this cased the Kafka handler module to never be imported, so no handler functions were ever registered. Use the same pattern as Ook and move the Kafka router into its own module to avoid circular dependencies.