### PR TITLE
DM-50277: Fix parsing of Qserv submit response

### DIFF
--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -110,4 +110,13 @@ class AsyncSubmitRequest(BaseModel):
 class AsyncSubmitResponse(BaseResponse):
     """Response from creating an async job."""
 
-    query_id: Annotated[int, Field(title="Query ID")]
+    model_config = ConfigDict(validate_by_name=True)
+
+    query_id: Annotated[
+        int,
+        Field(
+            title="Query ID",
+            serialization_alias="queryId",
+            validation_alias="queryId",
+        ),
+    ]


### PR DESCRIPTION
A validation alias was not set up for `queryId`.