### PR TITLE
DM-50277: Use 30s timeout for Qserv HTTP requests

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -64,7 +64,7 @@ class ProcessContext:
         logger = get_logger("qservkafka")
 
         # Qserv currently uses a self-signed certificate.
-        http_client = AsyncClient(verify=False)  # noqa: S501
+        http_client = AsyncClient(timeout=30, verify=False)  # noqa: S501
 
         # Qserv uses a self-signed certificate with no known certificate
         # chain. We do not use TLS to validate the identity of the server.


### PR DESCRIPTION
Use a longer timeout, since the httpx default is very aggressive and seems to often fail.