### PR TITLE
DM-50277: Update package installations

### DIFF
--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -26,5 +26,7 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git
+# Install some additional debugging tools that are useful for diagnosing
+# issues talking to Qserv.
+apt-get -y install --no-install-recommends curl default-mysql-client \
+    netcat-traditional

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -21,7 +21,7 @@ set -x
 # feedback:
 export DEBIAN_FRONTEND=noninteractive
 
-# Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.  libffi-dev
-# is sometimes needed to build cffi (a cryptography dependency).
-apt-get -y install --no-install-recommends build-essential libffi-dev
+# build-essential is sometimes required by Python dependencies that build C
+# modules. git is required during package installation for setuptools_scm.
+# libffi-dev is sometimes needed to build cffi (a cryptography dependency).
+apt-get -y install --no-install-recommends build-essential git libffi-dev


### PR DESCRIPTION
Move the installation of git to dependency packages, since it's only required when installing the package source. Install curl, mysql-client, and netcat-traditional in the container so that more debugging tools are available.