### PR TITLE
Change cache target to /root/.cache/uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Install the application itself.
 ADD . /app
-RUN --mount=type=cache,target=/.root/.cache/uv \
+RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps --compile-bytecode .
 
 FROM base-image AS runtime-image


### PR DESCRIPTION
I noticed this discrepancy in the root directories for the uv caches. I'm not sure it'll make a huge difference, but wanted to clarify before we roll this into templates.