### PR TITLE
DM-50391: Process multiple completed jobs simultaneously

### DIFF
--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -88,6 +88,17 @@ class Config(BaseSettings):
         ),
     )
 
+    shutdown_timeout: HumanTimedelta = Field(
+        timedelta(minutes=1),
+        title="Timeout for shutdown",
+        description=(
+            "How long to wait for result processing to finish during shutdown"
+            " before aborting. Qserv deletes results once retrieved, so"
+            " aborting result processing risks losing a result. This should"
+            " be aligned with the Kubernetes shutdown grace period."
+        ),
+    )
+
     @field_validator("qserv_database_url")
     @classmethod
     def _validate_qserv_database_url(cls, v: MySQLDsn) -> MySQLDsn:

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -361,6 +361,7 @@ class JobErrorCode(StrEnum):
     backend_error = "backend_error"
     backend_internal_error = "backend_internal_error"
     backend_request_error = "backend_request_error"
+    backend_sql_error = "backend_sql_error"
     invalid_request = "invalid_request"
     upload_failed = "upload_failed"
 

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -203,8 +203,12 @@ class QueryMonitor:
             total_rows = await self._votable.store(
                 job.result_url, job.result_format, results
             )
-        except UploadWebError as e:
-            self._logger.exception("Unable to upload results", error=str(e))
+        except (QservApiError, UploadWebError) as e:
+            if isinstance(e, UploadWebError):
+                msg = "Unable to upload results"
+            else:
+                msg = "Unable to retrieve results"
+            self._logger.exception(msg, error=str(e))
             update = JobStatus(
                 job_id=job.job_id,
                 execution_id=str(query_id),

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -74,11 +74,12 @@ class QueryMonitor:
             queries. This allows multiple completed queries to be processed
             simultaneously using the MySQL client connection pool.
         """
-        known_queries = await self._state.get_active_queries()
-        if not known_queries:
+        active_queries = await self._state.get_active_queries()
+        queries_to_process = active_queries - self._in_progress
+        if not queries_to_process:
             return
         running = await self._qserv.list_running_queries()
-        for query_id in known_queries:
+        for query_id in queries_to_process:
             query = await self._state.get_query(query_id)
             if not query:
                 continue

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -153,8 +153,11 @@ class QueryService:
                 total_rows = await self._votable.store(
                     job.result_url, job.result_format, results
                 )
-            except UploadWebError as e:
-                msg = "Unable to upload results"
+            except (QservApiError, UploadWebError) as e:
+                if isinstance(e, UploadWebError):
+                    msg = "Unable to upload results"
+                else:
+                    msg = "Unable to retrieve results"
                 logger.exception(msg, error=str(e))
                 return JobStatus(
                     job_id=job.job_id,
@@ -169,6 +172,7 @@ class QueryService:
                 result_location=job.result_location,
                 format=job.result_format.format,
             )
+            logger.info("Job complete and results uploaded")
 
         # Return the job status message for Kafka.
         return JobStatus(

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
+from ..config import config
 from ..exceptions import QservApiError, UploadWebError
 from ..models.kafka import (
     JobError,
@@ -149,10 +151,13 @@ class QueryService:
             await self._state.add_query(query_id, job, status)
         elif status.status == AsyncQueryPhase.COMPLETED:
             results = self._qserv.get_query_results_gen(query_id)
+            start = datetime.now(tz=UTC)
+            timeout = config.shutdown_timeout.total_seconds()
             try:
-                total_rows = await self._votable.store(
-                    job.result_url, job.result_format, results
-                )
+                async with asyncio.timeout(timeout):
+                    total_rows = await self._votable.store(
+                        job.result_url, job.result_format, results
+                    )
             except (QservApiError, UploadWebError) as e:
                 if isinstance(e, UploadWebError):
                     msg = "Unable to upload results"
@@ -167,12 +172,22 @@ class QueryService:
                     error=e.to_job_error(),
                     metadata=job.to_job_metadata(),
                 )
-            result_info = JobResultInfo(
-                total_rows=total_rows,
-                result_location=job.result_location,
-                format=job.result_format.format,
-            )
-            logger.info("Job complete and results uploaded")
+            except TimeoutError:
+                elapsed = datetime.now(tz=UTC) - start
+                logger.exception(
+                    "Retrieving results timed out",
+                    elapsed=elapsed.total_seconds,
+                    timeout=timeout,
+                )
+                status.status = AsyncQueryPhase.EXECUTING
+                await self._state.add_query(query_id, job, status)
+            else:
+                result_info = JobResultInfo(
+                    total_rows=total_rows,
+                    result_location=job.result_location,
+                    format=job.result_format.format,
+                )
+                logger.info("Job complete and results uploaded")
 
         # Return the job status message for Kafka.
         return JobStatus(

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -68,15 +68,15 @@ class QueryStateStore:
         """
         await self._storage.delete(str(query_id))
 
-    async def get_active_queries(self) -> list[int]:
+    async def get_active_queries(self) -> set[int]:
         """Get the IDs of all active queries.
 
         Returns
         -------
-        list of int
+        set of int
             All queries we believe are currently active.
         """
-        return [int(k) async for k in self._storage.scan("*")]
+        return {int(k) async for k in self._storage.scan("*")}
 
     async def get_query(self, query_id: int) -> Query | None:
         """Get the original job request for a given query.


### PR DESCRIPTION
Use the aiojobs scheduler to handle completed jobs as background tasks, allowing us to manage multiple job completions in parallel up to the aiojobs queue (100) and the httpx and SQLAlchemy connection pools (smaller than that). Add a new configuration setting for how long to wait to shut down result processing when terminating the application, and wait for jobs to complete for that long before shutting down gracefully.

Improve error handling of SQL failures, fixing a bug that was seen during testing when the results table for a query wasn't found for some reason.