### PR TITLE
DM-50410: Add support for job cancellation

### DIFF
--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -36,6 +36,10 @@ class Config(BaseSettings):
         title="Kafka connection settings",
     )
 
+    job_cancel_topic: str = Field(
+        "lsst.tap.job-delete", title="Topic for job cancellation requests"
+    )
+
     job_run_topic: str = Field(
         "lsst.tap.job-run", title="Topic for job requests"
     )

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -195,10 +195,11 @@ class Factory:
             qserv_client=QservClient(
                 self._session, self._context.http_client, self._logger
             ),
+            state_store=self._context.state,
             votable_writer=VOTableWriter(
                 self._context.http_client, self._logger
             ),
-            state_store=self._context.state,
+            kafka_broker=kafka_router.broker,
             logger=self._logger,
         )
 

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -32,6 +32,7 @@ type DatetimeMillis = Annotated[
 """Type for timestamps, which are represented in Kafka in milliseconds."""
 
 __all__ = [
+    "JobCancel",
     "JobError",
     "JobErrorCode",
     "JobMetadata",
@@ -44,6 +45,39 @@ __all__ = [
     "JobRun",
     "JobStatus",
 ]
+
+
+class JobCancel(BaseModel):
+    """Request to cancel a running query."""
+
+    model_config = ConfigDict(validate_by_name=True)
+
+    job_id: Annotated[
+        str,
+        Field(
+            title="UWS job ID",
+            description="Identifier of job in the TAP server's UWS database",
+            validation_alias="jobID",
+        ),
+    ]
+
+    execution_id: Annotated[
+        str,
+        Field(
+            title="Backend execution ID",
+            description="Identifier of the running query in the backend",
+            validation_alias="executionID",
+        ),
+    ]
+
+    owner: Annotated[
+        str,
+        Field(
+            title="Username of owner",
+            description="Username of the user who generated the query",
+            validation_alias="ownerID",
+        ),
+    ]
 
 
 class JobResultEnvelope(BaseModel):

--- a/tests/data/status/simple-aborted.json
+++ b/tests/data/status/simple-aborted.json
@@ -1,0 +1,16 @@
+{
+  "job_id": "uws123",
+  "execution_id": "1",
+  "timestamp": 1743540792,
+  "status": "ABORTED",
+  "query_info": {
+    "start_time": 1743540791,
+    "end_time": 1743540792,
+    "total_chunks": 10,
+    "completed_chunks": 0
+  },
+  "metadata": {
+    "query": "SELECT TOP 10 * FROM table",
+    "database": "dp1"
+  }
+}


### PR DESCRIPTION
Also listen to the Kafka queue for job cancellation messages, and use the Qserv REST API to cancel the job and immediately retrieve its new status.