### PR TITLE
DM-50410: Add serialization for VOTableArraySize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,6 @@ filterwarnings = [
     # do we specify lifespan_context. Perhaps with TestKafkaBroker and the
     # fixture setup?
     "ignore:Specifying 'lifespan_context' manually.*:UserWarning:contextlib",
-    # Bug in pydantic, see https://github.com/pydantic/pydantic/issues/10964
-    "ignore:Pydantic serializer warnings.*:UserWarning",
 ]
 # The python_files setting is not for test detection (pytest will pick up any
 # test files named *_test.py without this setting) but to enable special

--- a/src/qservkafka/models/votable.py
+++ b/src/qservkafka/models/votable.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Annotated, Any, Self
 
-from pydantic import BaseModel, Field, PlainValidator
+from pydantic import BaseModel, Field, PlainSerializer, PlainValidator
 
 __all__ = [
     "VOTableArraySize",
@@ -20,6 +20,13 @@ class VOTableSize(BaseModel):
     limit: Annotated[int | None, Field(title="Maximum length")]
 
     variable: Annotated[bool, Field(title="Whether length can vary")]
+
+    def to_string(self) -> str:
+        """Convert to string form as seen in VOTables."""
+        result = str(self.limit) if self.limit is not None else ""
+        if self.variable:
+            result += "*"
+        return result
 
 
 def _validate_array_size(arraysize: Any) -> VOTableSize:
@@ -40,7 +47,9 @@ def _validate_array_size(arraysize: Any) -> VOTableSize:
 
 
 type VOTableArraySize = Annotated[
-    VOTableSize, PlainValidator(_validate_array_size)
+    VOTableSize,
+    PlainSerializer(lambda v: v.to_string(), return_type=str),
+    PlainValidator(_validate_array_size),
 ]
 
 


### PR DESCRIPTION
Add a serializer that's parallel to the validator for `VOTableArraySize`. This is not strictly needed since the bridge was happy with the `dict` serialization, but it makes Pydantic warnings due to a pydantic-core bug go away and they're annoying in the logs.