### PR TITLE
DM-50410: Refactor query service layer

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -117,11 +117,19 @@ class ProcessContext:
             connect_args={"ssl": ssl_context},
         )
         session = await create_async_session(engine)
+        qserv_client = QservClient(session, http_client, logger)
+        votable_writer = VOTableWriter(http_client, logger)
+        query_service = QueryService(
+            qserv_client=qserv_client,
+            state_store=state_store,
+            votable_writer=votable_writer,
+            kafka_broker=kafka_router.broker,
+            logger=logger,
+        )
         monitor = QueryMonitor(
+            query_service=query_service,
             qserv_client=QservClient(session, http_client, logger),
             state_store=state_store,
-            votable_writer=VOTableWriter(http_client, logger),
-            kafka_broker=kafka_router.broker,
             logger=logger,
         )
         background = BackgroundTaskManager(monitor, logger)

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -397,6 +397,7 @@ class JobErrorCode(StrEnum):
     backend_request_error = "backend_request_error"
     backend_sql_error = "backend_sql_error"
     invalid_request = "invalid_request"
+    result_timeout = "result_timeout"
     upload_failed = "upload_failed"
 
 

--- a/src/qservkafka/models/votable.py
+++ b/src/qservkafka/models/votable.py
@@ -32,7 +32,7 @@ class VOTableSize(BaseModel):
 
 
 def _validate_array_size(arraysize: Any) -> VOTableSize:
-    """Verify that a VOTable arraysize is in a valid format."""
+    """Convert the string representation of `VOTableSize` to an object."""
     if isinstance(arraysize, VOTableSize):
         return arraysize
     elif isinstance(arraysize, dict):

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -2,28 +2,17 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime
 
 from aiojobs import Scheduler
-from faststream.kafka import KafkaBroker
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
-from ..config import config
-from ..exceptions import QservApiError, UploadWebError
-from ..models.kafka import (
-    JobError,
-    JobErrorCode,
-    JobQueryInfo,
-    JobResultInfo,
-    JobRun,
-    JobStatus,
-)
-from ..models.qserv import AsyncQueryPhase, AsyncQueryStatus
+from ..exceptions import QservApiError
+from ..models.kafka import JobRun, JobStatus
 from ..storage.qserv import QservClient
 from ..storage.state import QueryStateStore
-from ..storage.votable import VOTableWriter
+from .query import QueryService
 
 __all__ = ["QueryMonitor"]
 
@@ -33,14 +22,12 @@ class QueryMonitor:
 
     Parameters
     ----------
+    query_service
+        Query service used to process queries.
     qserv_client
         Client to talk to the Qserv REST API.
     state_store
         Storage for query state.
-    votable_writer
-        Writer for VOTable output.
-    kafka_broker
-        Broker to use to publish status messages.
     logger
         Logger to use.
     """
@@ -48,16 +35,14 @@ class QueryMonitor:
     def __init__(
         self,
         *,
+        query_service: QueryService,
         qserv_client: QservClient,
         state_store: QueryStateStore,
-        votable_writer: VOTableWriter,
-        kafka_broker: KafkaBroker,
         logger: BoundLogger,
     ) -> None:
+        self._query = query_service
         self._qserv = qserv_client
         self._state = state_store
-        self._votable = votable_writer
-        self._kafka = kafka_broker
         self._logger = logger
 
         # Completed jobs that are currently being processed, so that we don't
@@ -87,7 +72,8 @@ class QueryMonitor:
             if query_id in running:
                 status = running[query_id]
                 if query.status != status:
-                    await self._send_status(job, status)
+                    update = await self._query.build_status(job, status)
+                    await self._query.publish_status(update)
                     await self._state.update_status(query_id, job, status)
             elif query_id not in self._in_progress:
                 self._in_progress.add(query_id)
@@ -117,216 +103,18 @@ class QueryMonitor:
                 error=e.to_job_error(),
                 metadata=job.to_job_metadata(),
             )
-            await self._publish_status(update)
+            await self._query.publish_status(update)
             await self._state.delete_query(query_id)
             self._in_progress.remove(query_id)
             return
 
-        success = True
-        match status.status:
-            case AsyncQueryPhase.EXECUTING:
-                logger.error(
-                    "Job executing but not in process list",
-                    job_id=job.job_id,
-                    username=job.owner,
-                    status=status.model_dump(mode="json"),
-                )
-                # Do nothing and hope that the job either finishes or shows up
-                # in the process list the next time through.
-                return
-            case AsyncQueryPhase.COMPLETED:
-                success = await self._send_completed(query_id, job, status)
-            case AsyncQueryPhase.FAILED:
-                await self._send_failed(job, status)
-            case AsyncQueryPhase.ABORTED:
-                await self._send_aborted(job, status)
-            case _:  # pragma: no cover
-                raise ValueError(f"Unknown phase {status.status}")
+        # Analyze the status and retrieve and upload the results if needed.
+        update = await self._query.build_status(job, status)
 
-        # Clean up the handled query.
-        if success:
+        # Publish the results.
+        await self._query.publish_status(update)
+
+        # Clean up the handled query if it is no longer executing.
+        if update.status != ExecutionPhase.EXECUTING:
             await self._state.delete_query(query_id)
-            self._in_progress.remove(query_id)
-
-    async def _publish_status(self, status: JobStatus) -> None:
-        """Publish a status update to Kafka.
-
-        Parameters
-        ----------
-        status
-            Status update to publish.
-        """
-        await self._kafka.publish(
-            status.model_dump(mode="json"),
-            config.job_status_topic,
-            headers={"Content-Type": "application/json"},
-        )
-
-    async def _send_aborted(
-        self, job: JobRun, status: AsyncQueryStatus
-    ) -> None:
-        """Send a status update for an aborted job.
-
-        Parameters
-        ----------
-        job
-            Original query request.
-        status
-            Status of the job.
-        """
-        self._logger.info(
-            "Job aborted",
-            job_id=job.job_id,
-            qserv_id=status.query_id,
-            username=job.owner,
-        )
-        update = JobStatus(
-            job_id=job.job_id,
-            execution_id=str(status.query_id),
-            timestamp=status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.ABORTED,
-            query_info=JobQueryInfo.from_query_status(status),
-            metadata=job.to_job_metadata(),
-        )
-        await self._publish_status(update)
-
-    async def _send_completed(
-        self, query_id: int, job: JobRun, status: AsyncQueryStatus
-    ) -> bool:
-        """Send a status update for a completed job.
-
-        Parameters
-        ----------
-        query_id
-            Qserv query ID.
-        job
-            Original query request.
-        status
-            Status of the job.
-
-        Returns
-        -------
-        bool
-            `True` if the result was successfully retrieved and uploaded,
-            `False` otherwise.
-        """
-        logger = self._logger.bind(
-            job_id=job.job_id, qserv_id=query_id, username=job.owner
-        )
-        logger.debug("Processing job completion")
-
-        # Retrieve and upload the results.
-        start = datetime.now(tz=UTC)
-        timeout = config.shutdown_timeout.total_seconds()
-        results = self._qserv.get_query_results_gen(query_id)
-        try:
-            async with asyncio.timeout(timeout):
-                total_rows = await self._votable.store(
-                    job.result_url, job.result_format, results
-                )
-        except (QservApiError, UploadWebError) as e:
-            if isinstance(e, UploadWebError):
-                msg = "Unable to upload results"
-            else:
-                msg = "Unable to retrieve results"
-            logger.exception(msg, error=str(e))
-            update = JobStatus(
-                job_id=job.job_id,
-                execution_id=str(query_id),
-                timestamp=datetime.now(tz=UTC),
-                status=ExecutionPhase.ERROR,
-                error=e.to_job_error(),
-                metadata=job.to_job_metadata(),
-            )
-            await self._publish_status(update)
-            return False
-        except TimeoutError:
-            elapsed = datetime.now(tz=UTC) - start
-            logger.exception(
-                "Retrieving results timed out",
-                elapsed=elapsed.total_seconds,
-                timeout=timeout,
-            )
-            return False
-        logger.info("Job complete and results uploaded")
-
-        # Send the Kafka message indicating job completion.
-        update = JobStatus(
-            job_id=job.job_id,
-            execution_id=str(status.query_id),
-            timestamp=status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.COMPLETED,
-            query_info=JobQueryInfo.from_query_status(status),
-            result_info=JobResultInfo(
-                total_rows=total_rows,
-                result_location=job.result_location,
-                format=job.result_format.format,
-            ),
-            metadata=job.to_job_metadata(),
-        )
-        await self._publish_status(update)
-        return True
-
-    async def _send_failed(
-        self, job: JobRun, status: AsyncQueryStatus
-    ) -> None:
-        """Send a status update for a failed job.
-
-        Currently, Qserv has no way of reporting an error, so we have to
-        synthesize an error.
-
-        Parameters
-        ----------
-        job
-            Original query request.
-        status
-            Status of the job.
-        """
-        metadata = job.to_job_metadata()
-        self._logger.warning(
-            "Backend reported query failure",
-            job_id=job.job_id,
-            query=metadata.model_dump(mode="json", exclude_none=True),
-            status=status.model_dump(mode="json", exclude_none=True),
-        )
-        update = JobStatus(
-            job_id=job.job_id,
-            execution_id=str(status.query_id),
-            timestamp=status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.ERROR,
-            query_info=JobQueryInfo.from_query_status(status),
-            error=JobError(
-                code=JobErrorCode.backend_error,
-                message="Query failed in backend",
-            ),
-            metadata=metadata,
-        )
-        await self._publish_status(update)
-
-    async def _send_status(
-        self, job: JobRun, status: AsyncQueryStatus
-    ) -> None:
-        """Send a status update for a job that's still executing.
-
-        Parameters
-        ----------
-        job
-            Original query request.
-        status
-            Status of the job.
-        """
-        self._logger.debug(
-            "Sending job status update",
-            job_id=job.job_id,
-            qserv_id=status.query_id,
-            username=job.owner,
-        )
-        update = JobStatus(
-            job_id=job.job_id,
-            execution_id=str(status.query_id),
-            timestamp=status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.EXECUTING,
-            query_info=JobQueryInfo.from_query_status(status),
-            metadata=job.to_job_metadata(),
-        )
-        await self._publish_status(update)
+        self._in_progress.remove(query_id)

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -31,7 +31,7 @@ __all__ = ["QueryService"]
 
 
 class QueryService:
-    """Start new queries.
+    """Start or cancel queries.
 
     Parameters
     ----------
@@ -61,6 +61,39 @@ class QueryService:
         self._votable = votable_writer
         self._kafka = kafka_broker
         self._logger = logger
+
+    async def build_status(
+        self, job: JobRun, status: AsyncQueryStatus
+    ) -> JobStatus:
+        """Build the status response for a query.
+
+        If the query has already completed, retrieve the results if successful
+        and return an appropriate final status. Otherwise, return a status
+        message indicating that the job has started executing.
+
+        Parameters
+        ----------
+        job
+            Initial query request.
+        status
+            Status response from Qserv.
+
+        Returns
+        -------
+        JobStatus
+            Job status to report to Kafka.
+        """
+        match status.status:
+            case AsyncQueryPhase.ABORTED:
+                return self._build_aborted_status(job, status)
+            case AsyncQueryPhase.EXECUTING:
+                return self._build_executing_status(job, status)
+            case AsyncQueryPhase.COMPLETED:
+                return await self._build_completed_status(job, status)
+            case AsyncQueryPhase.FAILED:
+                return self._build_failed_status(job, status)
+            case _:  # pragma: no cover
+                raise ValueError(f"Unknown phase {status.status}")
 
     async def cancel_query(self, message: JobCancel) -> JobStatus | None:
         """Cancel a running query.
@@ -102,7 +135,7 @@ class QueryService:
             return None
 
         # Return an appropriate status update for the job's current status.
-        return await self._build_status(query_id, query.job, status)
+        return await self.build_status(query.job, status)
 
     async def publish_status(self, status: JobStatus) -> None:
         """Publish a status update to Kafka.
@@ -138,12 +171,12 @@ class QueryService:
         serialization = job.result_format.format.serialization
         if serialization != JobResultSerialization.BINARY2:
             msg = f"{serialization} serialization not supported"
-            return self._build_invalid_request_error(job, msg)
+            return self._build_invalid_request_status(job, msg)
         for column in job.result_format.column_types:
             is_char = column.datatype == VOTablePrimitive.char
             if not is_char and column.arraysize is not None:
                 msg = "arraysize only supported for char fields"
-                return self._build_invalid_request_error(job, msg)
+                return self._build_invalid_request_status(job, msg)
 
         # Start the query.
         logger.info(
@@ -165,28 +198,142 @@ class QueryService:
                 metadata=metadata,
             )
 
-        # Analyze the initial status and store the query if it successfully
-        # went into executing.
-        result = await self._build_status(query_id, job, status)
+        # Analyze the initial status and store the query if it is still
+        # executing.
+        result = await self.build_status(job, status)
         if result.status == ExecutionPhase.EXECUTING:
             await self._state.add_query(query_id, job, status)
         return result
 
-    async def _build_status(
-        self, query_id: int, job: JobRun, status: AsyncQueryStatus
+    def _build_aborted_status(
+        self, job: JobRun, status: AsyncQueryStatus
     ) -> JobStatus:
-        """Build the status response for a query.
+        """Construct the status for an aborted job.
 
-        If the query has already completed, retrieve the results if successful
-        and return an appropriate final status. Otherwise, return a status
-        message indicating that the job has started executing.
+        Parameters
+        ----------
+        job
+            Original query request.
+        status
+            Status from Qserv.
+
+        Returns
+        -------
+        JobStatus
+            Status for the query.
+        """
+        self._logger.info(
+            "Job aborted",
+            job_id=job.job_id,
+            qserv_id=status.query_id,
+            username=job.owner,
+        )
+        return JobStatus(
+            job_id=job.job_id,
+            execution_id=str(status.query_id),
+            timestamp=status.last_update or datetime.now(tz=UTC),
+            status=ExecutionPhase.ABORTED,
+            query_info=JobQueryInfo.from_query_status(status),
+            metadata=job.to_job_metadata(),
+        )
+
+    async def _build_completed_status(
+        self, job: JobRun, status: AsyncQueryStatus
+    ) -> JobStatus:
+        """Retrieve results and construct status for a completed job.
+
+        This method is responsible for retrieving the results from Qserv,
+        encoding them, and uploading the resulting VOTable to the provided
+        URL, as well as constructing the status response.
 
         Parameters
         ----------
         query_id
             Qserv query ID.
         job
-            Initial query request.
+            Original query request.
+        status
+            Status from Qserv.
+
+        Returns
+        -------
+        JobStatus
+            Status for the query.
+        """
+        query_id = status.query_id
+        logger = self._logger.bind(
+            job_id=job.job_id, qserv_id=query_id, username=job.owner
+        )
+        logger.debug("Processing job completion")
+
+        # Retrieve and upload the results.
+        start = datetime.now(tz=UTC)
+        timeout = config.shutdown_timeout.total_seconds()
+        results = self._qserv.get_query_results_gen(query_id)
+        try:
+            async with asyncio.timeout(timeout):
+                total_rows = await self._votable.store(
+                    job.result_url, job.result_format, results
+                )
+        except (QservApiError, UploadWebError) as e:
+            if isinstance(e, UploadWebError):
+                msg = "Unable to upload results"
+            else:
+                msg = "Unable to retrieve results"
+            elapsed = (datetime.now(tz=UTC) - start).total_seconds()
+            logger.exception(msg, error=str(e), elapsed=elapsed)
+            return JobStatus(
+                job_id=job.job_id,
+                execution_id=str(query_id),
+                timestamp=datetime.now(tz=UTC),
+                status=ExecutionPhase.ERROR,
+                error=e.to_job_error(),
+                metadata=job.to_job_metadata(),
+            )
+        except TimeoutError:
+            elapsed = (datetime.now(tz=UTC) - start).total_seconds()
+            logger.exception(
+                "Retrieving and uploading results timed out",
+                elapsed=elapsed,
+                timeout=timeout,
+            )
+            return JobStatus(
+                job_id=job.job_id,
+                execution_id=str(query_id),
+                timestamp=datetime.now(tz=UTC),
+                status=ExecutionPhase.ERROR,
+                error=JobError(
+                    code=JobErrorCode.result_timeout,
+                    message="Retrieving and uploading results timed out",
+                ),
+                metadata=job.to_job_metadata(),
+            )
+        logger.info("Job complete and results uploaded")
+
+        # Return the resulting status.
+        return JobStatus(
+            job_id=job.job_id,
+            execution_id=str(status.query_id),
+            timestamp=status.last_update or datetime.now(tz=UTC),
+            status=ExecutionPhase.COMPLETED,
+            query_info=JobQueryInfo.from_query_status(status),
+            result_info=JobResultInfo(
+                total_rows=total_rows,
+                result_location=job.result_location,
+                format=job.result_format.format,
+            ),
+            metadata=job.to_job_metadata(),
+        )
+
+    def _build_executing_status(
+        self, job: JobRun, status: AsyncQueryStatus
+    ) -> JobStatus:
+        """Build the status for a query that's still executing.
+
+        Parameters
+        ----------
+        job
+            Original query request.
         status
             Status response from Qserv.
 
@@ -195,76 +342,64 @@ class QueryService:
         JobStatus
             Job status to report to Kafka.
         """
-        logger = self._logger.bind(
-            job_id=job.job_id, qserv_id=query_id, username=job.owner
+        self._logger.debug(
+            "Query is executing",
+            job_id=job.job_id,
+            qserv_id=status.query_id,
+            username=job.owner,
         )
-        metadata = job.to_job_metadata()
-        error = None
-        result_info = None
-
-        # Check the status of the job according to Qserv.
-        if status.status == AsyncQueryPhase.FAILED:
-            logger.warning(
-                "Backend reported query failure",
-                query=metadata.model_dump(mode="json", exclude_none=True),
-            )
-            error = JobError(
-                code=JobErrorCode.backend_error,
-                message="Query failed in backend",
-            )
-        elif status.status == AsyncQueryPhase.COMPLETED:
-            results = self._qserv.get_query_results_gen(query_id)
-            start = datetime.now(tz=UTC)
-            timeout = config.shutdown_timeout.total_seconds()
-            try:
-                async with asyncio.timeout(timeout):
-                    total_rows = await self._votable.store(
-                        job.result_url, job.result_format, results
-                    )
-            except (QservApiError, UploadWebError) as e:
-                if isinstance(e, UploadWebError):
-                    msg = "Unable to upload results"
-                else:
-                    msg = "Unable to retrieve results"
-                logger.exception(msg, error=str(e))
-                return JobStatus(
-                    job_id=job.job_id,
-                    execution_id=str(query_id),
-                    timestamp=datetime.now(tz=UTC),
-                    status=ExecutionPhase.ERROR,
-                    error=e.to_job_error(),
-                    metadata=job.to_job_metadata(),
-                )
-            except TimeoutError:
-                elapsed = datetime.now(tz=UTC) - start
-                logger.exception(
-                    "Retrieving results timed out",
-                    elapsed=elapsed.total_seconds,
-                    timeout=timeout,
-                )
-                status.status = AsyncQueryPhase.EXECUTING
-                await self._state.add_query(query_id, job, status)
-            else:
-                result_info = JobResultInfo(
-                    total_rows=total_rows,
-                    result_location=job.result_location,
-                    format=job.result_format.format,
-                )
-                logger.info("Job complete and results uploaded")
-
-        # Return the job status message for Kafka.
         return JobStatus(
             job_id=job.job_id,
-            execution_id=str(query_id),
+            execution_id=str(status.query_id),
             timestamp=status.last_update or datetime.now(tz=UTC),
-            status=status.status.to_execution_phase(),
+            status=ExecutionPhase.EXECUTING,
             query_info=JobQueryInfo.from_query_status(status),
-            result_info=result_info,
-            error=error,
+            metadata=job.to_job_metadata(),
+        )
+
+    def _build_failed_status(
+        self, job: JobRun, status: AsyncQueryStatus
+    ) -> JobStatus:
+        """Build the status for a failed job.
+
+        Currently, Qserv has no way of reporting an error, so we have to
+        synthesize an error.
+
+        Parameters
+        ----------
+        job
+            Original query request.
+        status
+            Status from Qserv.
+
+        Returns
+        -------
+        JobStatus
+            Status for the query.
+        """
+        metadata = job.to_job_metadata()
+        self._logger.warning(
+            "Backend reported query failure",
+            job_id=job.job_id,
+            qserv_id=status.query_id,
+            username=job.owner,
+            query=metadata.model_dump(mode="json", exclude_none=True),
+            status=status.model_dump(mode="json", exclude_none=True),
+        )
+        return JobStatus(
+            job_id=job.job_id,
+            execution_id=str(status.query_id),
+            timestamp=status.last_update or datetime.now(tz=UTC),
+            status=ExecutionPhase.ERROR,
+            query_info=JobQueryInfo.from_query_status(status),
+            error=JobError(
+                code=JobErrorCode.backend_error,
+                message="Query failed in backend",
+            ),
             metadata=metadata,
         )
 
-    def _build_invalid_request_error(
+    def _build_invalid_request_status(
         self, job: JobRun, error: str
     ) -> JobStatus:
         """Build a status reply for an invalid request.

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -144,7 +144,7 @@ async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     # Return a normal reply from the status endpoint but mark the job as being
     # in an error state.
     query_status = AsyncQueryStatus(
-        query_id=3,
+        query_id=4,
         status=AsyncQueryPhase.FAILED,
         total_chunks=10,
         completed_chunks=4,


### PR DESCRIPTION
Previously, there was a lot of duplicate code between the query monitor and the query service, since the query service also had to process job status updates and generate an appropriate Kafka message. Unify that code in the query service and have the query monitor use the query service to process status updates.