### PR TITLE
DM-50410: Rename shutdown_timeout to result_timeout

### DIFF
--- a/src/qservkafka/background.py
+++ b/src/qservkafka/background.py
@@ -74,7 +74,7 @@ class BackgroundTaskManager:
             return
         self._logger.info("Stopping background tasks")
         self._closing = True
-        timeout = config.shutdown_timeout.total_seconds()
+        timeout = config.result_timeout.total_seconds() + 1.0
         await self._scheduler.wait_and_close(timeout=timeout)
         self._closing = False
         self._scheduler = None

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -92,14 +92,15 @@ class Config(BaseSettings):
         ),
     )
 
-    shutdown_timeout: HumanTimedelta = Field(
-        timedelta(minutes=1),
-        title="Timeout for shutdown",
+    result_timeout: HumanTimedelta = Field(
+        timedelta(minutes=10),
+        title="Timeout for result processing",
         description=(
-            "How long to wait for result processing to finish during shutdown"
-            " before aborting. Qserv deletes results once retrieved, so"
-            " aborting result processing risks losing a result. This should"
-            " be aligned with the Kubernetes shutdown grace period."
+            "How long to wait for result processing: retrieving the result"
+            " rows from Qserv, encoding them, and writing them to the upload"
+            " PUT URL. Qserv deletes results once retrieved, so aborting"
+            " result processing risks losing a result. This should be aligned"
+            " with the Kubernetes shutdown grace period."
         ),
     )
 

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -268,7 +268,7 @@ class QueryService:
 
         # Retrieve and upload the results.
         start = datetime.now(tz=UTC)
-        timeout = config.shutdown_timeout.total_seconds()
+        timeout = config.result_timeout.total_seconds()
         results = self._qserv.get_query_results_gen(query_id)
         try:
             async with asyncio.timeout(timeout):


### PR DESCRIPTION
`shutdown_timeout` is really `result_timeout`; it's just also used during shutdown. Rename it to a more accurate name.