### PR TITLE
DM-50410: Add tests for immediate completion

### DIFF
--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -58,8 +58,8 @@ class Config(BaseSettings):
         Profile.production, title="Application logging profile"
     )
 
-    redis_password: SecretStr | None = Field(
-        None, title="Redis password", description="Password for Redis server"
+    redis_password: SecretStr = Field(
+        ..., title="Redis password", description="Password for Redis server"
     )
 
     redis_url: RedisDsn = Field(

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -89,9 +89,7 @@ class ProcessContext:
         ssl_context.verify_mode = ssl.CERT_NONE
 
         # Create a Redis client pool with exponential backoff.
-        redis_password = None
-        if config.redis_password:
-            redis_password = config.redis_password.get_secret_value()
+        redis_password = config.redis_password.get_secret_value()
         backoff = ExponentialBackoff(
             base=REDIS_BACKOFF_START, cap=REDIS_BACKOFF_MAX
         )

--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -7,7 +7,6 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 from safir.pydantic import UtcDatetime
-from vo_models.uws.types import ExecutionPhase
 
 __all__ = [
     "AsyncQueryPhase",
@@ -44,19 +43,6 @@ class AsyncQueryPhase(StrEnum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     ABORTED = "ABORTED"
-
-    def to_execution_phase(self) -> ExecutionPhase:
-        match self.value:
-            case "EXECUTING":
-                return ExecutionPhase.EXECUTING
-            case "COMPLETED":
-                return ExecutionPhase.COMPLETED
-            case "FAILED":
-                return ExecutionPhase.ERROR
-            case "ABORTED":
-                return ExecutionPhase.ABORTED
-            case _:  # pragma: no cover
-                raise ValueError(f"Unknown phase {self.value}")
 
 
 class AsyncQueryStatus(BaseModel):

--- a/tests/data/status/data-completed.json
+++ b/tests/data/status/data-completed.json
@@ -5,6 +5,7 @@
   "status": "COMPLETED",
   "query_info": {
     "start_time": 1743540791,
+    "end_time": 1743540791,
     "total_chunks": 10,
     "completed_chunks": 10
   },


### PR DESCRIPTION
Add a test for immediate completion of the job during creation, and add a test for SQL failures when attempting to read the results of the job.