### PR TITLE
DM-50481: Remove some unused code

### DIFF
--- a/src/qservkafka/dependencies/context.py
+++ b/src/qservkafka/dependencies/context.py
@@ -2,7 +2,6 @@
 
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
-from typing import Any
 
 from faststream.kafka import KafkaBroker
 from faststream.kafka.fastapi import KafkaMessage
@@ -29,17 +28,6 @@ class ConsumerContext:
 
     factory: Factory
     """The component factory."""
-
-    def rebind_logger(self, **values: Any) -> None:
-        """Add the given values to the logging context.
-
-        Parameters
-        ----------
-        **values
-            Additional values that should be added to the logging context.
-        """
-        self.logger = self.logger.bind(**values)
-        self.factory.set_logger(self.logger)
 
 
 class ContextDependency:

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -227,16 +227,3 @@ class Factory:
             kafka_broker=self._context.kafka_broker,
             logger=self._logger,
         )
-
-    def set_logger(self, logger: BoundLogger) -> None:
-        """Replace the internal logger.
-
-        Used by the context dependency to update the logger for all
-        newly-created components when it's rebound with additional context.
-
-        Parameters
-        ----------
-        logger
-            New logger.
-        """
-        self._logger = logger

--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -23,7 +23,6 @@ async def job_run(
     message: JobRun,
     context: Annotated[ConsumerContext, Depends(context_dependency)],
 ) -> JobStatus:
-    context.rebind_logger(job_id=message.job_id, username=message.owner)
     query_service = context.factory.create_query_service()
     return await query_service.start_query(message)
 
@@ -32,9 +31,6 @@ async def job_cancel(
     message: JobCancel,
     context: Annotated[ConsumerContext, Depends(context_dependency)],
 ) -> None:
-    context.rebind_logger(
-        qserv_id=message.execution_id, username=message.owner
-    )
     query_service = context.factory.create_query_service()
     result = await query_service.cancel_query(message)
     if result:

--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -66,7 +66,7 @@ async def test_job_run(
             last_update=now,
         ),
     )
-    await asyncio.sleep(1)
+    await asyncio.sleep(1.1)
     expected["queryInfo"]["completedChunks"] = 5
     expected["queryInfo"]["startTime"] = int(
         async_status.query_begin.timestamp() * 1000
@@ -87,7 +87,7 @@ async def test_job_run(
             last_update=now,
         ),
     )
-    await asyncio.sleep(1)
+    await asyncio.sleep(1.1)
     expected["errorInfo"] = {
         "errorCode": "backend_error",
         "errorMessage": "Query failed in backend",


### PR DESCRIPTION
Stop rebinding the logger in the Kafka handlers, since the service layer already does this (and has to, for proper logging when called by the background monitor), and remove the code for rebinding loggers since it's now dead.