### PR TITLE
DM-50481: Fix state management after aborting a query

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -208,6 +208,11 @@ class Factory:
         self._logger = logger
         self._background_services_started = False
 
+    @property
+    def query_state_store(self) -> QueryStateStore:
+        """Underlying state storage for queries."""
+        return self._context.state
+
     def create_query_service(self) -> QueryService:
         """Create a new service for starting queries.
 
@@ -220,7 +225,7 @@ class Factory:
             qserv_client=QservClient(
                 self._session, self._context.http_client, self._logger
             ),
-            state_store=self._context.state,
+            state_store=self.query_state_store,
             votable_writer=VOTableWriter(
                 self._context.http_client, self._logger
             ),

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -135,7 +135,10 @@ class QueryService:
             return None
 
         # Return an appropriate status update for the job's current status.
-        return await self.build_status(query.job, status)
+        result = await self.build_status(query.job, status)
+        if result.status != ExecutionPhase.EXECUTING:
+            await self._state.delete_query(query_id)
+        return result
 
     async def publish_status(self, status: JobStatus) -> None:
         """Publish a status update to Kafka.

--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -15,6 +15,7 @@ from safir.datetime import current_datetime
 from vo_models.uws.types import ExecutionPhase
 
 from qservkafka.config import config
+from qservkafka.dependencies.context import context_dependency
 from qservkafka.models.kafka import (
     JobCancel,
     JobError,
@@ -98,6 +99,10 @@ async def test_job_run(
     expected["timestamp"] = int(now.timestamp() * 1000)
     status_publisher.mock.assert_called_once_with(expected)
 
+    assert context_dependency._process_context
+    state = context_dependency._process_context.state
+    assert await state.get_active_queries() == set()
+
 
 @pytest.mark.asyncio
 async def test_job_results(
@@ -139,6 +144,10 @@ async def test_job_results(
     expected["queryInfo"]["endTime"] = int(now.timestamp() * 1000)
     expected["timestamp"] = int(now.timestamp() * 1000)
     status_publisher.mock.assert_called_once_with(expected)
+
+    assert context_dependency._process_context
+    state = context_dependency._process_context.state
+    assert await state.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -197,6 +206,10 @@ async def test_job_result_error(
     expected["timestamp"] = ANY
     status_publisher.mock.assert_called_once_with(expected)
 
+    assert context_dependency._process_context
+    state = context_dependency._process_context.state
+    assert await state.get_active_queries() == set()
+
 
 @pytest.mark.asyncio
 async def test_job_cancel(
@@ -229,3 +242,7 @@ async def test_job_cancel(
     expected["queryInfo"]["startTime"] = ANY
     expected["queryInfo"]["endTime"] = ANY
     status_publisher.mock.assert_called_once_with(expected)
+
+    assert context_dependency._process_context
+    state = context_dependency._process_context.state
+    assert await state.get_active_queries() == set()

--- a/tests/handlers/shutdown_test.py
+++ b/tests/handlers/shutdown_test.py
@@ -169,12 +169,15 @@ async def test_shutdown(
                 last_update=now,
             ),
         )
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(1.1)
 
     expected["queryInfo"]["startTime"] = ANY
     expected["queryInfo"]["endTime"] = ANY
     expected["timestamp"] = ANY
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(1)
     raw_message = await kafka_status_consumer.getone()
     message = json.loads(raw_message.value.decode())
     assert message == expected
+
+    redis_client = redis.get_client()
+    assert set(redis_client.scan_iter("query:*")) == set()

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -43,6 +43,8 @@ async def test_start(factory: Factory) -> None:
     assert status.query_info
     assert_approximately_now(status.query_info.start_time)
 
+    assert await factory.query_state_store.get_active_queries() == {1}
+
 
 @pytest.mark.asyncio
 async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
@@ -58,6 +60,8 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     assert status.query_info
     assert_approximately_now(status.query_info.start_time)
     assert_approximately_now(status.query_info.end_time)
+
+    assert await factory.query_state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -101,6 +105,8 @@ async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.error.code = JobErrorCode.backend_error
     expected.error.message = "Qserv request failed: Some error"
     assert status == expected
+
+    assert await factory.query_state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -192,6 +198,8 @@ async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     assert status.query_info
     assert_approximately_now(status.query_info.start_time)
 
+    assert await factory.query_state_store.get_active_queries() == set()
+
 
 @pytest.mark.asyncio
 async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
@@ -231,6 +239,8 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.timestamp = ANY
     assert status == expected
 
+    assert await factory.query_state_store.get_active_queries() == set()
+
 
 @pytest.mark.asyncio
 async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
@@ -256,6 +266,8 @@ async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.timestamp = ANY
     assert status == expected
     assert_approximately_now(status.timestamp)
+
+    assert await factory.query_state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -288,3 +300,5 @@ async def test_upload_timeout(
     expected.timestamp = ANY
     assert status == expected
     assert_approximately_now(status.timestamp)
+
+    assert await factory.query_state_store.get_active_queries() == set()


### PR DESCRIPTION
Add tests for proper Redis contents after all tests that track query state, and fix a bug in state handling after aborting a query.