### PR TITLE
DM-50527: Log elapsed time of result processing

### DIFF
--- a/changelog.d/20250505_155326_rra_DM_50527a.md
+++ b/changelog.d/20250505_155326_rra_DM_50527a.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Add the elapsed time to the log message sent when result processing is finished.

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -311,7 +311,11 @@ class QueryService:
                 ),
                 metadata=job.to_job_metadata(),
             )
-        logger.info("Job complete and results uploaded", rows=total_rows)
+        logger.info(
+            "Job complete and results uploaded",
+            rows=total_rows,
+            elapsed=(datetime.now(tz=UTC) - start).total_seconds(),
+        )
 
         # Return the resulting status.
         return JobStatus(


### PR DESCRIPTION
After we finish processing and uploading rows, log how long it took to perform that step.