### PR TITLE
DM-50728: Configure an arq job timeout

### DIFF
--- a/src/qservkafka/constants.py
+++ b/src/qservkafka/constants.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 __all__ = [
+    "ARQ_TIMEOUT_GRACE",
     "REDIS_BACKOFF_MAX",
     "REDIS_BACKOFF_START",
     "REDIS_POOL_SIZE",
@@ -10,6 +13,14 @@ __all__ = [
     "REDIS_RETRIES",
     "REDIS_TIMEOUT",
 ]
+
+ARQ_TIMEOUT_GRACE = timedelta(seconds=2)
+"""Additional grace period to allow on top of result processing timeout.
+
+This should be long enough to allow for asking the REST API for the status,
+but still shorter than the additional grace period Kubernetes is configured
+to give the worker pod.
+"""
 
 REDIS_BACKOFF_MAX = 1.0
 """Maximum delay (in seconds) to wait after a Redis failure."""

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -11,6 +11,7 @@ from safir.logging import configure_logging
 from structlog import get_logger
 
 from ..config import config
+from ..constants import ARQ_TIMEOUT_GRACE
 from ..factory import Factory, ProcessContext
 from .functions.results import handle_finished_query
 
@@ -57,6 +58,7 @@ class WorkerSettings:
     """Configuration for the arq worker."""
 
     functions: ClassVar[list[Callable]] = [handle_finished_query]
-    redis_settings = config.arq_redis_settings
+    job_timeout = config.result_timeout + ARQ_TIMEOUT_GRACE
     on_startup = startup
     on_shutdown = shutdown
+    redis_settings = config.arq_redis_settings


### PR DESCRIPTION
Use the Qserv Kafka bridge configuration option for specifying a result processing timeout as a job timeout in the arq configuration.