### PR TITLE
DM-50728: Add a maximum lifetime for Redis query objects

### DIFF
--- a/changelog.d/20250508_174532_rra_DM_50728.md
+++ b/changelog.d/20250508_174532_rra_DM_50728.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Forget about queries and drop them from Redis after one day as a last fallback to clean out stranded data in Redis.

--- a/src/qservkafka/constants.py
+++ b/src/qservkafka/constants.py
@@ -22,6 +22,16 @@ but still shorter than the additional grace period Kubernetes is configured
 to give the worker pod.
 """
 
+MAXIMUM_QUERY_LIFETIME = timedelta(days=1)
+"""How long before we forget about a query entirely.
+
+Various bugs and other issues may result in stranding a query in Redis with
+the flag set to indicate it has been dispatched by arq but without any active
+arq job processing it. As a last resort, tell Redis to forget about these
+queries after this interval. This will strand unretrieved results in Qserv
+that will have to be pruned by Qserv garbage collection.
+"""
+
 REDIS_BACKOFF_MAX = 1.0
 """Maximum delay (in seconds) to wait after a Redis failure."""
 

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from safir.redis import PydanticRedisStorage
 from structlog.stdlib import BoundLogger
 
+from ..constants import MAXIMUM_QUERY_LIFETIME
 from ..models.kafka import JobRun
 from ..models.qserv import AsyncQueryStatus
 from ..models.state import Query
@@ -83,7 +84,8 @@ class QueryStateStore:
         query = await self.get_query(query_id)
         if query:
             query.result_queued = True
-            await self._storage.store(str(query_id), query)
+            lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
+            await self._storage.store(str(query_id), query, lifetime)
 
     async def store_query(
         self,
@@ -118,4 +120,5 @@ class QueryStateStore:
                 status=status,
                 result_queued=result_queued,
             )
-        await self._storage.store(str(query_id), query)
+        lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
+        await self._storage.store(str(query_id), query, lifetime)


### PR DESCRIPTION
Various bugs and other issues may result in stranding a query in Redis with the flag set to indicate it has been dispatched by arq but without any active arq job processing it. As a last resort, tell Redis to forget about these queries after this interval. This will strand unretrieved results in Qserv that will have to be pruned by Qserv garbage collection.