### PR TITLE
DM-50728: Fix duplicate result processing bug in monitor

### DIFF
--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -53,6 +53,10 @@ class Config(BaseSettings):
         LogLevel.INFO, title="Log level of the application's logger"
     )
 
+    max_worker_jobs: int = Field(
+        5, title="Simultaneous result worker jobs per pod"
+    )
+
     name: str = Field("qserv-kafka", title="Name of application")
 
     profile: Profile = Field(

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -205,6 +205,8 @@ class VOTableEncoder:
                 encoded = self._encode_row(types, row)
                 yield encoded
                 self._total_rows += 1
+                if self._total_rows % 10000 == 0:
+                    self._logger.debug(f"Processed {self._total_rows} rows")
         finally:
             await results.aclose()
 

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -58,6 +58,9 @@ class WorkerSettings:
     """Configuration for the arq worker."""
 
     functions: ClassVar[list[Callable]] = [handle_finished_query]
+    job_completion_wait = int(
+        (config.result_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
+    )
     job_timeout = config.result_timeout + ARQ_TIMEOUT_GRACE
     on_startup = startup
     on_shutdown = shutdown

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -62,6 +62,7 @@ class WorkerSettings:
         (config.result_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
     )
     job_timeout = config.result_timeout + ARQ_TIMEOUT_GRACE
+    max_jobs = config.max_worker_jobs
     on_startup = startup
     on_shutdown = shutdown
     redis_settings = config.arq_redis_settings


### PR DESCRIPTION
If the background query status monitor found a still-executing query and then, when it went to send a status update, found that the query had completed before sending the response, it would process the results but still remember the query. The next pass through the monitor would then find the completed query and dispatch it to arq, which would fail because the results had already been deleted.

Fix this by only sending executing updates from the monitor loop and doing so without retrieving the status again.