### PR TITLE
DM-50728: Buffer uploads of query results

### DIFF
--- a/src/qservkafka/constants.py
+++ b/src/qservkafka/constants.py
@@ -12,6 +12,7 @@ __all__ = [
     "REDIS_POOL_TIMEOUT",
     "REDIS_RETRIES",
     "REDIS_TIMEOUT",
+    "UPLOAD_BUFFER_SIZE",
 ]
 
 ARQ_TIMEOUT_GRACE = timedelta(seconds=2)
@@ -53,3 +54,10 @@ REDIS_RETRIES = 10
 
 REDIS_TIMEOUT = 5
 """Timeout in seconds for a Redis network operation (including connecting)."""
+
+UPLOAD_BUFFER_SIZE = 64 * 1024
+"""Size of the internal buffer for HTTP PUT.
+
+Writes to the signed URL are buffered to avoid too many small writes and
+context switches. This is the size of the buffer.
+"""

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -216,7 +216,7 @@ class VOTableEncoder:
                 encoded = self._encode_row(types, row)
                 yield encoded
                 self._total_rows += 1
-                if self._total_rows % 10000 == 0:
+                if self._total_rows % 100000 == 0:
                     self._logger.debug(f"Processed {self._total_rows} rows")
         finally:
             await results.aclose()

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -108,7 +108,7 @@ class VOTableEncoder:
         try:
             async for blob in data:
                 buf += blob
-                if len(buf) >= input_line_length:
+                while len(buf) >= input_line_length:
                     view = memoryview(buf)
                     yield b2a_base64(view[:input_line_length])
                     view.release()

--- a/tests/handlers/shutdown_test.py
+++ b/tests/handlers/shutdown_test.py
@@ -156,7 +156,7 @@ async def test_shutdown(
     async with LifespanManager(app):
         await kafka_broker.publish(job_json, config.job_run_topic)
         await asyncio.sleep(0.1)
-        await kafka_status_consumer.getone()
+        await kafka_status_consumer.getmany()
 
         await mock_qserv.store_results(job)
         async_status = mock_qserv.get_status(1)


### PR DESCRIPTION
Try buffering the output of query result encoding in 64KB chunks to see if this improves performance of result processing.