### PR TITLE
DM-50961: Fix uncaught SQL exceptions

### DIFF
--- a/changelog.d/20250516_165313_rra_DM_50961.md
+++ b/changelog.d/20250516_165313_rra_DM_50961.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Catch more SQLAlchemy errors during result processing, hopefully closing an error case where result processing failed without sending an error reply or removing the query from Redis.


### PR DESCRIPTION
Fix several places where a database session was opened outside of a try/catch block, thus causing any resulting exception to be thrown uncaught. This in turn led to the worker failing without sending an error response to the TAP server and without removing the query from Redis.