### PR TITLE
DM-50964: Bump minimum version of arq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.13"
 dependencies = [
     "aiojobs>=1.3",
-    "arq>=0.23",
+    "arq>=0.26",
     "asyncmy>=0.2",
     "bitstring>=4.3",
     "fastapi>=0.112.2",


### PR DESCRIPTION
arq 0.26 added an upper version bound on some dependencies. Ensure at least that version is installed to prevent uv from downgrading arq in order to upgrade other dependencies that may not work properly with arq.