### PR TITLE
DM-51004: Explicitly close BytesIO used in VOTable encoding

### DIFF
--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -103,6 +103,7 @@ class VOTableEncoder:
             encoded.truncate()
             yield self._base64_encode_bytes(encoded, last=True)
         finally:
+            encoded.close()
             await results.aclose()
         footer = self._config.envelope.footer.encode()
         self._wrapper_size += len(footer)


### PR DESCRIPTION
Ensure that the `BytesIO` object used to encode results in `BINARY2` is always explicitly closed. This probably makes no difference since it should be garbage-collected anyway, but it feels more correct.