### PR TITLE
DM-51121: Retry queries found to still be executing

### DIFF
--- a/changelog.d/20250528_154140_rra_DM_51121.md
+++ b/changelog.d/20250528_154140_rra_DM_51121.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Correctly update the query state in the result worker if Qserv unexpectedly reports it as still running to ensure that it will be checked again and not simply dropped.

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -149,6 +149,9 @@ class QueryStateStore:
         """
         query = await self.get_query(query_id)
         if query:
+            query.result_queued = False
             query.status = status
             lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
-            await self._storage.store(str(query_id), query, lifetime)
+            await self._storage.store(
+                str(query_id), query, lifetime, exclude_defaults=True
+            )


### PR DESCRIPTION
If the arq result worker finds that a query that we thought was finished is reported by Qserv to still be executing, clear the flag saying it was dispatched to a result worker so that we will retry result processing.