### PR TITLE
DM-51121: Rework how result rows are iterated

### DIFF
--- a/changelog.d/20250528_154741_rra_DM_51121.md
+++ b/changelog.d/20250528_154741_rra_DM_51121.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- When result processing fails, close the streaming response from MySQL before attempting to roll back the transaction, hopefully suppressing otherwise unintelligible SQLAlchemy errors about packet sequences.


### PR DESCRIPTION
Explicitly configure the streaming query results to retrieve 100 rows at a time. (This should be made configurable later.) Add another `try` block to ensure that the results are closed before attempting to roll back a transaction, which will hopefully fix SQLAlchemy exceptions about invalid packet sequences.