### PR TITLE
DM-51121: Allow completed chunks to be None

### DIFF
--- a/changelog.d/20250528_161854_rra_DM_51121.md
+++ b/changelog.d/20250528_161854_rra_DM_51121.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Allow completed chunks as returned from the Qserv REST API to be `None` and treat that the same as 0.

--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -63,6 +63,7 @@ class AsyncQueryStatus(BaseModel):
         Field(
             title="Completed query chunks", validation_alias="completedChunks"
         ),
+        BeforeValidator(lambda v: 0 if v is None else v),
     ]
 
     query_begin: Annotated[


### PR DESCRIPTION
Qserv has started sometimes returning `None` for the completed chunks value. Treat that the same as 0.