### PR TITLE
DM-51308: Bump Qserv API to 41

### DIFF
--- a/changelog.d/20250609_081648_rra_DM_51308.md
+++ b/changelog.d/20250609_081648_rra_DM_51308.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Request version 41 of the Qserv REST API instead of version 39.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -32,7 +32,7 @@ from ..models.qserv import (
     BaseResponse,
 )
 
-API_VERSION = 39
+API_VERSION = 41
 """Version of the REST API that this client requests."""
 
 _QUERY_LIST_SQL = """


### PR DESCRIPTION
Expect the new Qserv API version 41. This is safe without any further changes. Support for new API features will be added in subsequent requests.