### PR TITLE
DM-51308: Explicitly delete results from Qserv

### DIFF
--- a/changelog.d/20250609_104115_rra_DM_51308.md
+++ b/changelog.d/20250609_104115_rra_DM_51308.md
@@ -1,0 +1,3 @@
+### New features
+
+- Explicitly delete results from Qserv after they have been successfully retrieved.

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -299,10 +299,16 @@ class ResultProcessor:
             elapsed=(now - result_start).total_seconds(),
         )
 
+        # Delete the results.
+        try:
+            await self._qserv.delete_result(query_id)
+        except QservApiError:
+            logger.exception("Cannot delete results")
+
         # Return the resulting status.
         return JobStatus(
             job_id=job.job_id,
-            execution_id=str(status.query_id),
+            execution_id=str(query_id),
             timestamp=status.last_update or datetime.now(tz=UTC),
             status=ExecutionPhase.COMPLETED,
             query_info=JobQueryInfo.from_query_status(status),

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -100,6 +100,25 @@ class QservClient:
         """
         await self._delete(f"/query-async/{query_id}")
 
+    async def delete_result(self, query_id: int) -> None:
+        """Delete the results of a query.
+
+        This should be called after the results have been successfully
+        retrieved, although it is not a disaster if it's not called. The
+        results will be automatically garbage-collected after some time.
+
+        Parameters
+        ----------
+        query_id
+            Identifier of the query.
+
+        Raises
+        ------
+        QservApiError
+            Raised if there was some error deleting the results.
+        """
+        await self._delete(f"/query-async/result/{query_id}")
+
     async def get_query_results_gen(
         self, query_id: int
     ) -> AsyncGenerator[Row[Any]]:

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -61,6 +61,14 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     assert_approximately_now(status.query_info.start_time)
     assert_approximately_now(status.query_info.end_time)
 
+    # It should be possible to immediately run the same query again. This
+    # tests that the results were deleted from the database, and thus can be
+    # re-added.
+    expected_status.execution_id = "2"
+    mock_qserv.set_immediate_success(job)
+    status = await query_service.start_query(job)
+    assert status == expected_status
+
     assert await factory.query_state_store.get_active_queries() == set()
 
 


### PR DESCRIPTION
The new Qserv version 41 API does not automatically delete results once they have been retrieved and has a new HTTP REST API for deleting results. Use that API to delete results only after they have been successfully retrieved.