### PR TITLE
DM-51310: Retry most HTTP requests on failure

### DIFF
--- a/changelog.d/20250609_180548_rra_DM_51308.md
+++ b/changelog.d/20250609_180548_rra_DM_51308.md
@@ -1,0 +1,3 @@
+### New features
+
+- Retry HTTP requests to Qserv, and to retrieve user table uploads, up to three times on HTTP request failure, pausing for one second between requests. This will hopefully work around ongoing network instability.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,13 +141,17 @@ async def kafka_broker(
         yield broker
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(ids=["good", "flaky"], params=[False, True])
 async def mock_qserv(
-    respx_mock: respx.Router, engine: AsyncEngine
+    respx_mock: respx.Router,
+    engine: AsyncEngine,
+    request: pytest.FixtureRequest,
 ) -> AsyncGenerator[MockQserv]:
     """Mock the Qserv REST API."""
     url = str(config.qserv_rest_url)
     async with register_mock_qserv(respx_mock, url, engine) as mock_qserv:
+        if request.param:
+            mock_qserv.set_intermittent_failure()
         yield mock_qserv
 
 

--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -264,7 +264,13 @@ async def test_job_cancel(
     expected["timestamp"] = ANY
     expected["queryInfo"]["startTime"] = ANY
     expected["queryInfo"]["endTime"] = ANY
-    status_publisher.mock.assert_called_once_with(expected)
+
+    # If we're testing flaky connections, there may be a 3s delay.
+    try:
+        status_publisher.mock.assert_called_once_with(expected)
+    except AssertionError:
+        await asyncio.sleep(3)
+        status_publisher.mock.assert_called_with(expected)
 
     assert context_dependency._process_context
     state = context_dependency._process_context.state

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -30,6 +30,7 @@ from ..support.qserv import MockQserv
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mock_qserv", [False], ids=["good"], indirect=True)
 @pytest.mark.timeout(60)
 async def test_success(
     *,

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -64,7 +64,8 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     # It should be possible to immediately run the same query again. This
     # tests that the results were deleted from the database, and thus can be
     # re-added.
-    expected_status.execution_id = "2"
+    assert expected_status.execution_id
+    expected_status.execution_id = str(int(expected_status.execution_id) + 1)
     mock_qserv.set_immediate_success(job)
     status = await query_service.start_query(job)
     assert status == expected_status
@@ -199,13 +200,9 @@ async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.query_info = JobQueryInfo(
         start_time=now, end_time=now, total_chunks=10, completed_chunks=4
     )
-    expected.query_info.start_time = ANY
-    expected.query_info.end_time = ANY
     expected.error.code = JobErrorCode.backend_error
     expected.error.message = "Query failed in backend"
     assert status == expected
-    assert status.query_info
-    assert_approximately_now(status.query_info.start_time)
 
     assert await factory.query_state_store.get_active_queries() == set()
 


### PR DESCRIPTION
If HTTP requests to Qserv or to retrieve user-uploaded tables fail, retry up to three times pausing for one second between retries. Hopefully this will work around ongoing SLAC network instability. As yet this does not apply to MySQL connections or the streaming upload of results, since those require different handling.