### PR TITLE
DM-51310: Add new tests for query cancelation

### DIFF
--- a/tests/data/cancel/simple.json
+++ b/tests/data/cancel/simple.json
@@ -1,0 +1,5 @@
+{
+  "jobID": "uws123",
+  "executionID": "1",
+  "ownerID": "username"
+}

--- a/tests/services/query_errors_test.py
+++ b/tests/services/query_errors_test.py
@@ -20,7 +20,7 @@ from qservkafka.models.kafka import (
 from qservkafka.models.qserv import AsyncQueryPhase, AsyncQueryStatus
 from qservkafka.storage import qserv
 
-from ..support.data import read_test_job_run
+from ..support.data import read_test_job_cancel, read_test_job_run
 from ..support.datetime import assert_approximately_now
 from ..support.qserv import MockQserv
 
@@ -260,3 +260,12 @@ async def test_upload_timeout(
     assert_approximately_now(status.timestamp)
 
     assert await factory.query_state_store.get_active_queries() == set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_unknown(factory: Factory) -> None:
+    """Test canceling an unknown job."""
+    query_service = factory.create_query_service()
+    cancel = read_test_job_cancel("cancel/simple")
+
+    assert await query_service.cancel_query(cancel) is None

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import pytest
 
 from qservkafka.factory import Factory
+from qservkafka.models.kafka import JobStatus
 
-from ..support.data import read_test_job_run, read_test_job_status
+from ..support.data import (
+    read_test_job_cancel,
+    read_test_job_run,
+    read_test_job_status,
+)
 from ..support.datetime import assert_approximately_now
 from ..support.qserv import MockQserv
 
@@ -51,3 +56,28 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     assert status == expected_status
 
     assert await factory.query_state_store.get_active_queries() == set()
+
+
+@pytest.mark.asyncio
+async def test_start_cancel(factory: Factory) -> None:
+    job = read_test_job_run("jobs/simple")
+    started_status = read_test_job_status("status/simple-started")
+    cancel = read_test_job_cancel("cancel/simple")
+    canceled_status = read_test_job_status("status/simple-aborted")
+    query_service = factory.create_query_service()
+
+    status: JobStatus | None = await query_service.start_query(job)
+    assert status == started_status
+    assert_approximately_now(status.timestamp)
+    assert status.query_info
+    assert_approximately_now(status.query_info.start_time)
+    start_time = status.query_info.start_time
+
+    assert await factory.query_state_store.get_active_queries() == {1}
+
+    status = await query_service.cancel_query(cancel)
+    assert status == canceled_status
+    assert_approximately_now(status.timestamp)
+    assert status.query_info
+    assert status.query_info.start_time == start_time
+    assert_approximately_now(status.query_info.end_time)

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import ANY
 
-from qservkafka.models.kafka import JobRun, JobStatus
+from qservkafka.models.kafka import JobCancel, JobRun, JobStatus
 
 __all__ = [
     "read_test_data",
@@ -58,6 +58,23 @@ def read_test_json(filename: str) -> Any:
     path = Path(__file__).parent.parent / "data" / (filename + ".json")
     with path.open("r") as f:
         return json.load(f)
+
+
+def read_test_job_cancel(filename: str) -> JobCancel:
+    """Read test data parsed as a Kafka message to cancel a query.
+
+    Parameters
+    ----------
+    filename
+        File to read relative to the test data directory, without the
+        ``.json`` suffix.
+
+    Returns
+    -------
+    JobCancel
+        Parsed contents of the file.
+    """
+    return JobCancel.model_validate(read_test_json(filename))
 
 
 def read_test_job_run(filename: str) -> JobRun:


### PR DESCRIPTION
Add service-level tests for query cancelation and canceling an unknown query. These will be tested with flaky web services, which allows us to disable flaky web services for the end-to-end Kafka handler tests and thus avoid additional test delays.