### PR TITLE
DM-51310: Improve testing with flaky Qserv mock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,13 +141,29 @@ async def kafka_broker(
         yield broker
 
 
-@pytest_asyncio.fixture(ids=["good", "flaky"], params=[False, True])
+@pytest_asyncio.fixture(ids=["good"], params=[False])
 async def mock_qserv(
     respx_mock: respx.Router,
     engine: AsyncEngine,
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[MockQserv]:
-    """Mock the Qserv REST API."""
+    """Mock the Qserv REST API.
+
+    This mock is designed for pytest indirect parameterization. Tests that
+    want to use flaky web services that fail ever other time should inject a
+    parameter of `True`.
+
+    Examples
+    --------
+    Add the following mark before tests that should repeat the test with a
+    flaky web service.
+
+    .. code-block:: python
+
+       @pytest.mark.parametrize(
+           "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+       )
+    """
     url = str(config.qserv_rest_url)
     async with register_mock_qserv(respx_mock, url, engine) as mock_qserv:
         if request.param:

--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -264,13 +264,7 @@ async def test_job_cancel(
     expected["timestamp"] = ANY
     expected["queryInfo"]["startTime"] = ANY
     expected["queryInfo"]["endTime"] = ANY
-
-    # If we're testing flaky connections, there may be a 3s delay.
-    try:
-        status_publisher.mock.assert_called_once_with(expected)
-    except AssertionError:
-        await asyncio.sleep(3)
-        status_publisher.mock.assert_called_with(expected)
+    status_publisher.mock.assert_called_once_with(expected)
 
     assert context_dependency._process_context
     state = context_dependency._process_context.state

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -30,7 +30,6 @@ from ..support.qserv import MockQserv
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mock_qserv", [False], ids=["good"], indirect=True)
 @pytest.mark.timeout(60)
 async def test_success(
     *,

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -24,7 +24,6 @@ from ..support.qserv import MockQserv
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mock_qserv", [False], ids=["good"], indirect=True)
 async def test_success(
     *,
     factory: Factory,

--- a/tests/services/query_errors_test.py
+++ b/tests/services/query_errors_test.py
@@ -26,6 +26,9 @@ from ..support.qserv import MockQserv
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     job = read_test_job_run("jobs/simple")
     query_service = factory.create_query_service()
@@ -71,6 +74,9 @@ async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     job = read_test_job_run("jobs/simple")
     query_service = factory.create_query_service()
@@ -201,6 +207,9 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
     query_service = factory.create_query_service()
     job = read_test_job_run("jobs/data")

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -17,6 +17,9 @@ from ..support.qserv import MockQserv
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_start(factory: Factory) -> None:
     job = read_test_job_run("jobs/simple")
     expected_status = read_test_job_status("status/simple-started")
@@ -32,6 +35,9 @@ async def test_start(factory: Factory) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     """Test a job that completes immediately."""
     query_service = factory.create_query_service()
@@ -59,6 +65,9 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_start_cancel(factory: Factory) -> None:
     job = read_test_job_run("jobs/simple")
     started_status = read_test_job_status("status/simple-started")


### PR DESCRIPTION
Change the default parametrization of the Qserv mock to only run in normal mode, and instead parametrize for flaky mode only in the service tests. This should still cover the same error handling, but avoids adding delays to delay-sensitive tests via the Kafka handler that depend on background timing delays.