### PR TITLE
DM-51310: Move SQL queries to functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ async def factory(
         async with aclosing(context):
             session = await create_async_session(engine, logger)
             yield Factory(context, session, logger)
+    await kafka_broker.close()
 
 
 @pytest.fixture

--- a/tests/services/query_errors_test.py
+++ b/tests/services/query_errors_test.py
@@ -216,8 +216,8 @@ async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
     now = datetime.now(tz=UTC)
 
     mock_qserv.set_immediate_success(job)
-    sql = "SELECT * FROM nonexistent"
-    with patch.object(qserv, "_QUERY_RESULTS_SQL_FORMAT", new=sql):
+    results_sql = "SELECT * FROM nonexistent"
+    with patch.object(qserv, "_query_results_sql", return_value=results_sql):
         status = await query_service.start_query(job)
 
     expected = JobStatus(


### PR DESCRIPTION
In preparation for testing unstable SQL connections, move the constants for SQL query strings to functions. This shouldn't make much difference at runtime but allows the test suite to mock those functions and return alternating failing and successful queries in a future change.