### PR TITLE
DM-51310: Log metrics events for Qserv retries

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -219,7 +219,10 @@ class Factory:
             Client for the Qserv API.
         """
         return QservClient(
-            self._session, self._context.http_client, self._logger
+            session=self._session,
+            http_client=self._context.http_client,
+            events=self._context.events,
+            logger=self._logger,
         )
 
     async def create_query_monitor(self) -> QueryMonitor:


### PR DESCRIPTION
Add a new metrics event for a successful Qserv API call after a retry (failures will produce job errors and be accounted for separately). Teach the retry decorator how to publish that metrics event.

The code here is kind of ugly and hard to follow because Python doesn't offer a great way of running code only if a block didn't throw an exception (`try` can't be used without `except` or `finally`).