### PR TITLE
DM-51310: Add retries for SQL failures

### DIFF
--- a/changelog.d/20250610_181601_rra_DM_51310.md
+++ b/changelog.d/20250610_181601_rra_DM_51310.md
@@ -1,0 +1,3 @@
+### New features
+
+- Retry SQL requests to Qserv and result uploads up to three times, pausing for one second between attempts. This will hopefully work around ongoing network instability.

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from enum import StrEnum
 
 from pydantic import Field
 from safir.dependencies.metrics import EventMaker
@@ -12,6 +13,7 @@ from .models.kafka import JobErrorCode
 
 __all__ = [
     "Events",
+    "QservProtocol",
     "QservRetryEvent",
     "QueryAbortEvent",
     "QueryFailureEvent",
@@ -20,12 +22,21 @@ __all__ = [
 ]
 
 
+class QservProtocol(StrEnum):
+    """Protocol of Qserv API used."""
+
+    HTTP = "HTTP"
+    SQL = "SQL"
+
+
 class QservRetryEvent(EventPayload):
     """Number of retries for a successful Qserv API request.
 
     This event will only be logged if the API call eventually succeeds but had
     to be tried more than once.
     """
+
+    protocol: QservProtocol = Field(..., title="Protocol of Qserv API")
 
     retries: int = Field(..., title="Number of retries")
 

--- a/src/qservkafka/models/votable.py
+++ b/src/qservkafka/models/votable.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import struct
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from typing import Annotated, Any, Self
 
@@ -12,6 +13,7 @@ from pydantic import BaseModel, Field, PlainSerializer, PlainValidator
 
 __all__ = [
     "EncodedSize",
+    "UploadStats",
     "VOTableArraySize",
     "VOTablePrimitive",
     "VOTableSize",
@@ -30,6 +32,14 @@ class EncodedSize:
 
     total_bytes: int
     """Total size of the result in bytes, including the XML wrapper."""
+
+
+@dataclass
+class UploadStats(EncodedSize):
+    """Statistics about the uploaded result VOTable."""
+
+    elapsed: timedelta
+    """Time required to process and upload the results."""
 
 
 class VOTableSize(BaseModel):


### PR DESCRIPTION
Add retry logic for SQL calls to Qserv, similar to the retry logic for HTTP requests. Add special handling for result retrieval and uploading, since the entire operation needs to be retried together rather than retrying the individual underlying calls.