### PR TITLE
DM-51358: Support dropping API version in Qserv REST calls

### DIFF
--- a/changelog.d/20250611_155153_rra_DM_51309.md
+++ b/changelog.d/20250611_155153_rra_DM_51309.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow disabling the sending of the expected Qserv REST API version on each request. This allows the Qserv Kafka bridge to work with newer Qserv REST API versions without modification, provided that the new REST API is backwards-compatible.

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -121,6 +121,16 @@ class Config(BaseSettings):
         ),
     )
 
+    qserv_rest_send_api_version: bool = Field(
+        True,
+        title="Send Qserv REST API version",
+        description=(
+            "If true, send the expected Qserv REST API version as part of"
+            " each request, which will cause Qserv to reject the request if"
+            " the API version is not known"
+        ),
+    )
+
     qserv_rest_timeout: HumanTimedelta = Field(
         timedelta(seconds=30),
         title="Qserv REST timeout",

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -392,7 +392,6 @@ class QservClient:
                 "fields_terminated_by": ",",
                 "charset_name": "utf8",
                 "timeout": int(config.qserv_upload_timeout.total_seconds()),
-                "version": API_VERSION,
             },
             files=(
                 ("schema", ("schema.json", schema, "application/json")),
@@ -416,7 +415,10 @@ class QservClient:
         QservApiError
             Raised if something failed when issuing the DELETE request.
         """
-        params = {"version": str(API_VERSION)}
+        if config.qserv_rest_send_api_version:
+            params = {"version": str(API_VERSION)}
+        else:
+            params = None
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
             r = await self._client.delete(url, params=params)
@@ -454,7 +456,8 @@ class QservClient:
             Raised if something failed when issuing the GET request.
         """
         params_with_version = copy(params)
-        params_with_version["version"] = str(API_VERSION)
+        if config.qserv_rest_send_api_version:
+            params_with_version["version"] = str(API_VERSION)
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
             r = await self._client.get(url, params=params_with_version)
@@ -552,7 +555,8 @@ class QservClient:
             Raised if something failed when submitting the POST request.
         """
         body_dict = body.model_dump(mode="json", exclude_none=True)
-        body_dict["version"] = API_VERSION
+        if config.qserv_rest_send_api_version:
+            body_dict["version"] = API_VERSION
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
             r = await self._client.post(url, json=body_dict)
@@ -592,7 +596,8 @@ class QservClient:
             Raised if something failed when submitting the POST request.
         """
         params = dict(data)
-        params["version"] = API_VERSION
+        if config.qserv_rest_send_api_version:
+            params["version"] = API_VERSION
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
             r = await self._client.post(


### PR DESCRIPTION
Currently, Qserv's REST API only supports a single API version at a time. This means that if the Qserv Kafka bridge always sends an API version, both components have to be upgraded in lockstep. Add an option to disable sending the API version, which means Qserv will make a best effort to interpret the call, with some potential errors and misinterpretation if the semantics have changed.