### PR TITLE
DM-51364: Improve reporting of Qserv API failures

### DIFF
--- a/changelog.d/20250612_170316_rra_DM_51364.md
+++ b/changelog.d/20250612_170316_rra_DM_51364.md
@@ -1,0 +1,7 @@
+### Bug fixes
+
+- Fix retries of SQL connection failures when getting the list of active queries.
+
+### Other changes
+
+- Log metrics events for protocol errors when talking to Qserv with separate events for each failed attempt, rather than one event with a count of retries per eventually-successful API call.


### PR DESCRIPTION
Rather than reporting one metric for a Qserv API call that eventually succeeds, containing the count of retries, report a separate metrics event for each failure to contact the Qserv API that may be due to SQL or HTTP protocol issues.

Fix the retry logic in the SQL query that gets the current list of running queries from Qserv.