### PR TITLE
DM-51364: Support HTTP Basic Auth for Qserv REST API

### DIFF
--- a/changelog.d/20250613_110101_rra_DM_51364.md
+++ b/changelog.d/20250613_110101_rra_DM_51364.md
@@ -1,0 +1,3 @@
+### New features
+
+- Optionally support HTTP Basic Authentication for Qserv REST API calls.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -421,7 +421,9 @@ class QservClient:
             params = None
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
-            r = await self._client.delete(url, params=params)
+            r = await self._client.delete(
+                url, params=params, auth=config.rest_authentication
+            )
             r.raise_for_status()
             self.logger.debug(
                 "Qserv API reply", method="DELETE", url=url, result=r.json()
@@ -460,7 +462,11 @@ class QservClient:
             params_with_version["version"] = str(API_VERSION)
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
-            r = await self._client.get(url, params=params_with_version)
+            r = await self._client.get(
+                url,
+                params=params_with_version,
+                auth=config.rest_authentication,
+            )
             r.raise_for_status()
             self.logger.debug(
                 "Qserv API reply", method="GET", url=url, result=r.json()
@@ -559,7 +565,9 @@ class QservClient:
             body_dict["version"] = API_VERSION
         url = str(config.qserv_rest_url).rstrip("/") + route
         try:
-            r = await self._client.post(url, json=body_dict)
+            r = await self._client.post(
+                url, json=body_dict, auth=config.rest_authentication
+            )
             r.raise_for_status()
             self.logger.debug(
                 "Qserv API reply", method="POST", url=url, result=r.json()
@@ -605,6 +613,7 @@ class QservClient:
                 data=params,
                 files=files,
                 timeout=(timeout + timedelta(seconds=1)).total_seconds(),
+                auth=config.rest_authentication,
             )
             r.raise_for_status()
             self.logger.debug(


### PR DESCRIPTION
Optionally support sending HTTP Basic Authentication for the Qserv REST API.