### PR TITLE
DM-51365: Bump Qserv API version to 43

### DIFF
--- a/changelog.d/20250616_163206_rra_DM_51365.md
+++ b/changelog.d/20250616_163206_rra_DM_51365.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Request version 43 of the Qserv REST API instead of version 41.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -43,7 +43,7 @@ from ..models.qserv import (
     BaseResponse,
 )
 
-API_VERSION = 41
+API_VERSION = 43
 """Version of the REST API that this client requests."""
 
 __all__ = ["API_VERSION", "QservClient"]


### PR DESCRIPTION
This is the REST API version that expects version constraints as query strings and supports HTTP Basic Authentication.