### PR TITLE
DM-51448: Add test for retries of query status

### DIFF
--- a/tests/storage/qserv_test.py
+++ b/tests/storage/qserv_test.py
@@ -1,0 +1,31 @@
+"""Tests for the Qserv storage layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from qservkafka.factory import Factory
+
+from ..support.data import read_test_job_run, read_test_job_status
+from ..support.qserv import MockQserv
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
+async def test_list_running_queries(
+    factory: Factory, mock_qserv: MockQserv
+) -> None:
+    qserv = factory.create_qserv_client()
+    query_service = factory.create_query_service()
+    job = read_test_job_run("jobs/simple")
+    expected_status = read_test_job_status("status/simple-started")
+
+    processes = await qserv.list_running_queries()
+    assert processes == {}
+
+    status = await query_service.start_query(job)
+    assert status == expected_status
+    processes = await qserv.list_running_queries()
+    assert processes == {1: mock_qserv.get_status(1)}

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -438,6 +438,7 @@ class MockQserv:
                 total_chunks=10,
                 completed_chunks=0,
                 query_begin=now,
+                last_update=now,
             )
             async with self._session.begin():
                 process = _Process(


### PR DESCRIPTION
Add a test verifying that the Qserv SQL call to get the status of running queries is retried on failure. Adjust the Qserv mock to set the last update time in the query status after query creation.