### PR TITLE
DM-51448: Make delay and retry count configurable

### DIFF
--- a/changelog.d/20250618_112259_rra_DM_51448.md
+++ b/changelog.d/20250618_112259_rra_DM_51448.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow configuration of the number of retries for Qserv API network failures and the delay between retries. The defaults are 3 and one second, respectively.

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -169,6 +169,20 @@ class Config(BaseSettings):
         ),
     )
 
+    qserv_retry_count: int = Field(
+        3,
+        title="Number of Qserv retries",
+        description=(
+            "How many times to retry a Qserv API call before giving up"
+        ),
+    )
+
+    qserv_retry_delay: HumanTimedelta = Field(
+        timedelta(seconds=1),
+        title="Delay between Qserv retries",
+        description="How long to pause between retries of Qserv API calls",
+    )
+
     qserv_upload_timeout: HumanTimedelta = Field(
         timedelta(minutes=5),
         title="Qserv table upload timeout",


### PR DESCRIPTION
Allow the delay and retry count when retrying Qserv API calls after network errors configurable. Use that configuration to reduce the delay from 1s to 10ms in the test suite so that the test suite will run faster.