### PR TITLE
DM-51450: Delete temporary tables after query completion

### DIFF
--- a/changelog.d/20250618_140009_rra_DM_51450.md
+++ b/changelog.d/20250618_140009_rra_DM_51450.md
@@ -1,0 +1,3 @@
+### New features
+
+- Delete temporary table uploads from Qserv after completion of the query.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -243,6 +243,23 @@ class QservClient:
         """
         await self._delete(f"/query-async/result/{query_id}")
 
+    async def delete_table(self, database: str, table: str) -> None:
+        """Delete a user table.
+
+        Parameters
+        ----------
+        database
+            Name of the database (normally :samp:`user_{username}`).
+        table
+            Name of the table.
+
+        Raises
+        ------
+        QservApiError
+            Raised if there was some error deleting the table.
+        """
+        await self._delete(f"/ingest/table/{database}/{table}")
+
     async def get_query_results_gen(
         self, query_id: int
     ) -> AsyncGenerator[Row[Any]]:

--- a/tests/data/jobs/upload.json
+++ b/tests/data/jobs/upload.json
@@ -2,7 +2,8 @@
   "query": "SELECT TOP 10 * FROM user_username.table",
   "jobID": "uws123",
   "ownerID": "username",
-  "resultDestination": "https://gcs.example.com/upload",
+  "resultDestination": "https://results.example.com/1",
+  "resultLocation": "https://gcs.example.com/upload",
   "resultFormat": {
     "format": {
       "type": "VOTable",
@@ -15,9 +16,57 @@
     },
     "columnTypes": [
       {
-        "name": "col_0",
+        "name": "id",
+        "datatype": "int"
+      },
+      {
+        "name": "a",
+        "datatype": "boolean"
+      },
+      {
+        "name": "b",
+        "datatype": "char"
+      },
+      {
+        "name": "c",
+        "datatype": "char",
+        "arraysize": "10"
+      },
+      {
+        "name": "d",
+        "datatype": "char",
+        "arraysize": "*",
+        "requiresUrlRewrite": true
+      },
+      {
+        "name": "e",
+        "datatype": "double"
+      },
+      {
+        "name": "f",
+        "datatype": "float"
+      },
+      {
+        "name": "g",
+        "datatype": "int"
+      },
+      {
+        "name": "h",
+        "datatype": "long"
+      },
+      {
+        "name": "i",
+        "datatype": "char",
+        "arraysize": "4*"
+      },
+      {
+        "name": "j",
         "datatype": "char",
         "arraysize": "*"
+      },
+      {
+        "name": "k",
+        "datatype": "short"
       }
     ]
   },

--- a/tests/data/status/upload-completed.json
+++ b/tests/data/status/upload-completed.json
@@ -1,0 +1,23 @@
+{
+  "job_id": "uws123",
+  "execution_id": "1",
+  "timestamp": 1743540791,
+  "status": "COMPLETED",
+  "query_info": {
+    "start_time": 1743540791,
+    "end_time": 1743540791,
+    "total_chunks": 10,
+    "completed_chunks": 10
+  },
+  "result_info": {
+    "total_rows": 2,
+    "result_location": "https://gcs.example.com/upload",
+    "format": {
+      "type": "VOTable",
+      "serialization": "BINARY2"
+    }
+  },
+  "metadata": {
+    "query": "SELECT TOP 10 * FROM user_username.table"
+  }
+}


### PR DESCRIPTION
When uploading a temporary table for a query, delete the table from Qserv after the query completes (either successfully or unsuccessfully).