### PR TITLE
DM-51448: Move the query state store out of process context

### DIFF
--- a/src/qservkafka/workers/functions/results.py
+++ b/src/qservkafka/workers/functions/results.py
@@ -25,7 +25,7 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: int) -> None:
     factory: Factory = ctx["factory"]
     session: async_scoped_session = ctx["session"]
     logger: BoundLogger = ctx["logger"]
-    state = factory.query_state_store
+    state = factory.create_query_state_store()
 
     query = await state.get_query(query_id)
     if not query:

--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -108,9 +108,9 @@ async def test_job_run(
         headers={"Content-Type": "application/json"},
     )
 
-    assert context_dependency._process_context
-    state = context_dependency._process_context.state
-    assert await state.get_active_queries() == set()
+    factory = context_dependency.create_factory()
+    state_store = factory.create_query_state_store()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -161,9 +161,9 @@ async def test_job_results(
         headers={"Content-Type": "application/json"},
     )
 
-    assert context_dependency._process_context
-    state = context_dependency._process_context.state
-    assert await state.get_active_queries() == set()
+    factory = context_dependency.create_factory()
+    state_store = factory.create_query_state_store()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -229,9 +229,9 @@ async def test_job_result_error(
         headers={"Content-Type": "application/json"},
     )
 
-    assert context_dependency._process_context
-    state = context_dependency._process_context.state
-    assert await state.get_active_queries() == set()
+    factory = context_dependency.create_factory()
+    state_store = factory.create_query_state_store()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -266,9 +266,9 @@ async def test_job_cancel(
     expected["queryInfo"]["endTime"] = ANY
     status_publisher.mock.assert_called_once_with(expected)
 
-    assert context_dependency._process_context
-    state = context_dependency._process_context.state
-    assert await state.get_active_queries() == set()
+    factory = context_dependency.create_factory()
+    state_store = factory.create_query_state_store()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -312,6 +312,6 @@ async def test_job_upload(
     assert mock_qserv.get_uploaded_table() is None
 
     # There should be no more running jobs.
-    assert context_dependency._process_context
-    state = context_dependency._process_context.state
-    assert await state.get_active_queries() == set()
+    factory = context_dependency.create_factory()
+    state_store = factory.create_query_state_store()
+    assert await state_store.get_active_queries() == set()

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -32,6 +32,7 @@ from ..support.qserv import MockQserv
 async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     job = read_test_job_run("jobs/simple")
     query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC)
 
     # HTTP failure starting the job.
@@ -70,7 +71,7 @@ async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.error.message = "Qserv request failed: Some error"
     assert status == expected
 
-    assert await factory.query_state_store.get_active_queries() == set()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -80,6 +81,7 @@ async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
 async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     job = read_test_job_run("jobs/simple")
     query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC)
 
     # HTTP failure getting the job status.
@@ -162,12 +164,13 @@ async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.error.message = "Query failed in backend"
     assert status == expected
 
-    assert await factory.query_state_store.get_active_queries() == set()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
 async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC)
 
     job = read_test_job_run("jobs/tabledata")
@@ -203,7 +206,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     expected.timestamp = ANY
     assert status == expected
 
-    assert await factory.query_state_store.get_active_queries() == set()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -212,6 +215,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
 )
 async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
     query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
     job = read_test_job_run("jobs/data")
     now = datetime.now(tz=UTC)
 
@@ -234,7 +238,7 @@ async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
     assert status == expected
     assert_approximately_now(status.timestamp)
 
-    assert await factory.query_state_store.get_active_queries() == set()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio
@@ -246,6 +250,7 @@ async def test_upload_timeout(
     This should also cover a timeout in retrieving the data from SQL.
     """
     query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
     job = read_test_job_run("jobs/data")
 
     mock_qserv.set_immediate_success(job)
@@ -268,7 +273,7 @@ async def test_upload_timeout(
     assert status == expected
     assert_approximately_now(status.timestamp)
 
-    assert await factory.query_state_store.get_active_queries() == set()
+    assert await state_store.get_active_queries() == set()
 
 
 @pytest.mark.asyncio

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -51,6 +51,7 @@ async def test_success(
     factory._context.events = events
 
     query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
     job = read_test_job_run("jobs/data")
     expected_status = read_test_job_status("status/data-completed")
     mock_qserv.set_immediate_success(job)
@@ -63,7 +64,7 @@ async def test_success(
         expected_status.execution_id = str(i)
         assert status == expected_status
 
-    assert await factory.query_state_store.get_active_queries() == set()
+    assert await state_store.get_active_queries() == set()
 
     mock_qserv.reset()
     respx_mock.reset()


### PR DESCRIPTION
Now that query state is stored in Redis, we no longer need a global singleton query state store. Move it into the factory and create it on the fly when needed.