### PR TITLE
DM-51448: Improve check against real Kafka

### DIFF
--- a/tests/data/status/data-started.json
+++ b/tests/data/status/data-started.json
@@ -1,0 +1,15 @@
+{
+  "job_id": "uws123",
+  "execution_id": "1",
+  "timestamp": 1743540791,
+  "status": "EXECUTING",
+  "query_info": {
+    "start_time": 1743540791,
+    "total_chunks": 10,
+    "completed_chunks": 0
+  },
+  "metadata": {
+    "query": "SELECT TOP 10 * FROM table",
+    "database": "dp1"
+  }
+}


### PR DESCRIPTION
Test the intermediate status response after the job was started, and avoid one artificial delay by blocking on Kafka messages instead.