### PR TITLE
DM-51448: Test that finished queries aren't dispatched twice

### DIFF
--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -6,7 +6,9 @@ from safir.arq import ArqQueue
 from structlog.stdlib import BoundLogger
 
 from ..events import Events
-from ..models.qserv import AsyncQueryPhase
+from ..models.kafka import JobStatus
+from ..models.qserv import AsyncQueryPhase, AsyncQueryStatus
+from ..models.state import Query
 from ..storage.qserv import QservClient
 from ..storage.state import QueryStateStore
 from .results import ResultProcessor
@@ -60,36 +62,59 @@ class QueryMonitor:
             query = await self._state.get_query(query_id)
             if not query:
                 continue
-            job = query.job
-            logger = self._logger.bind(
-                job_id=job.job_id, qserv_id=str(query_id), username=job.owner
-            )
-            if query.result_queued:
-                logger.debug("Skipping already queued query")
-                continue
-
-            # Send updates to executing queries directly from the background
-            # monitoring task for faster updates, but make sure we do not
-            # accidentally process finished queries from the monitor task. We
-            # otherwise might send duplicate updates. Ensure all finished
-            # queries are dispatched to arq.
-            #
-            # Do not use build_query_status inside the first block, since it
-            # will re-retrieve the status from Qserv and may at that point
-            # find that it is completed.
-            is_running = (
-                query_id in running
-                and running[query_id].status == AsyncQueryPhase.EXECUTING
-            )
-            if is_running:
-                status = running[query_id]
-                if query.status == status:
-                    logger.debug("Running query has not changed state")
-                    continue
-                update = self._results.build_executing_status(job, status)
+            update = await self.check_query(query, running.get(query_id))
+            if update:
                 await self._results.publish_status(update)
-                await self._state.update_status(query_id, status)
-            else:
-                await self._arq.enqueue("handle_finished_query", query_id)
-                await self._state.mark_queued_query(query_id)
-                self._logger.debug("Dispatched finished query to worker")
+
+    async def check_query(
+        self, query: Query, status: AsyncQueryStatus | None
+    ) -> JobStatus | None:
+        """Check the status of one Qserv query.
+
+        If the query is complete, dispatch it to the result worker. Otherwise,
+        construct a status update for posting to Kafka, if warranted.
+
+        Parameters
+        ----------
+        query
+            Running query information.
+        status
+            Qserv status from the running process list, if the query appeared
+            there, or `None` otherwise.
+
+        Returns
+        -------
+        JobStatus or None
+            The status of the query, for posting to Kafka, or `None` if no
+            update is warranted.
+        """
+        query_id = query.query_id
+        job = query.job
+        logger = self._logger.bind(
+            job_id=job.job_id, qserv_id=str(query_id), username=job.owner
+        )
+        if query.result_queued:
+            logger.debug("Skipping already queued query")
+            return None
+
+        # Send updates to executing queries directly from the background
+        # monitoring task for faster updates, but make sure we do not
+        # accidentally process finished queries from the monitor task. We
+        # otherwise might send duplicate updates. Ensure all finished queries
+        # are dispatched to arq.
+        #
+        # Do not use build_query_status inside the first block, since it will
+        # re-retrieve the status from Qserv and may at that point find that it
+        # is completed.
+        if status and status.status == AsyncQueryPhase.EXECUTING:
+            if query.status == status:
+                logger.debug("Running query has not changed state")
+                return None
+            update = self._results.build_executing_status(job, status)
+            await self._state.update_status(query_id, status)
+            return update
+        else:
+            await self._arq.enqueue("handle_finished_query", query_id)
+            await self._state.mark_queued_query(query_id)
+            self._logger.debug("Dispatched finished query to worker")
+            return None

--- a/tests/services/monitor_test.py
+++ b/tests/services/monitor_test.py
@@ -1,0 +1,61 @@
+"""Tests for the query status monitor."""
+
+from __future__ import annotations
+
+from unittest.mock import call, patch
+
+import pytest
+from safir.arq import RedisArqQueue
+from safir.datetime import current_datetime
+
+from qservkafka.factory import Factory
+from qservkafka.models.qserv import AsyncQueryPhase, AsyncQueryStatus
+
+from ..support.data import read_test_job_run, read_test_job_status
+from ..support.qserv import MockQserv
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
+async def test_dispatch(factory: Factory, mock_qserv: MockQserv) -> None:
+    query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
+    monitor = await factory.create_query_monitor()
+    job = read_test_job_run("jobs/simple")
+    expected_status = read_test_job_status("status/simple-started")
+
+    status = await query_service.start_query(job)
+    assert status == expected_status
+
+    qserv_status = mock_qserv.get_status(1)
+    now = current_datetime()
+    await mock_qserv.update_status(
+        1,
+        AsyncQueryStatus(
+            query_id=1,
+            status=AsyncQueryPhase.COMPLETED,
+            total_chunks=10,
+            completed_chunks=10,
+            collected_bytes=250,
+            query_begin=qserv_status.query_begin,
+            last_update=now,
+        ),
+    )
+
+    query = await state_store.get_query(1)
+    assert query
+    qserv_status = mock_qserv.get_status(1)
+    with patch.object(RedisArqQueue, "enqueue") as mock:
+        assert await monitor.check_query(query, qserv_status) is None
+        assert mock.call_args_list == [call("handle_finished_query", 1)]
+        mock.reset_mock()
+
+        # Running a second check on the query should notice that the query was
+        # already dispatched from information stored in the state store and
+        # should not dispatch it again.
+        query = await state_store.get_query(1)
+        assert query
+        assert await monitor.check_query(query, qserv_status) is None
+        assert mock.call_args_list == []


### PR DESCRIPTION
Refactor the query status monitor code to make it easier to test and verify that completed queries aren't dispatched to the arq queue more than once.