### PR TITLE
DM-51594: Fix timings in query status

### DIFF
--- a/changelog.d/20250627_123645_rra_DM_51594.md
+++ b/changelog.d/20250627_123645_rra_DM_51594.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix query start and end times in status responses. Previously, the start time and, for canceled or completed queries, the end time were taken directly from the Qserv query information. This includes only time spent by Qserv, which results in an inaccurate picture of the query execution time in the TAP UWS table. Instead measure query timings from the time the query was received by the bridge to when it completes uploading of the results, or is aware of a failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["rubin", "lsst"]
 # https://pypi.org/classifiers/
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -17,7 +17,7 @@ from pydantic import (
 from safir.pydantic import SecondsTimedelta
 from vo_models.uws.types import ExecutionPhase
 
-from .qserv import AsyncQueryPhase, AsyncQueryStatus
+from .qserv import AsyncQueryStatus
 from .votable import VOTableArraySize, VOTablePrimitive
 
 type DatetimeMillis = Annotated[
@@ -421,27 +421,37 @@ class JobQueryInfo(BaseModel):
     ]
 
     @classmethod
-    def from_query_status(cls, status: AsyncQueryStatus) -> Self:
+    def from_query_status(
+        cls,
+        status: AsyncQueryStatus,
+        start: datetime,
+        *,
+        finished: bool = False,
+    ) -> Self:
         """Create a new object from the query status returned by Qserv.
 
         Parameters
         ----------
         status
             Query status to convert.
+        start
+            Start time of query, measured from the point at which the Qserv
+            Kafka bridge received the query.
+        finished
+            Whether the query is finished and therefore the end time should be
+            set to now.
 
         Returns
         -------
         JobQueryInfo
             Corresponding query information.
         """
-        result = cls(
-            start_time=status.query_begin,
+        return cls(
+            start_time=start,
             total_chunks=status.total_chunks,
             completed_chunks=status.completed_chunks,
+            end_time=datetime.now(tz=UTC) if finished else None,
         )
-        if status.status != AsyncQueryPhase.EXECUTING:
-            result.end_time = status.last_update
-        return result
 
 
 class JobResultInfo(BaseModel):

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -18,9 +18,7 @@ class Query(BaseModel):
 
     query_id: Annotated[int, Field(title="Qserv ID of query")]
 
-    start: Annotated[datetime | None, Field(title="Receipt time of query")] = (
-        None
-    )
+    start: Annotated[datetime, Field(title="Receipt time of query")]
 
     job: Annotated[JobRun, Field(title="Full job request")]
 

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -110,7 +110,9 @@ class QueryMonitor:
             if query.status == status:
                 logger.debug("Running query has not changed state")
                 return None
-            update = self._results.build_executing_status(job, status)
+            update = self._results.build_executing_status(
+                job, status, query.start
+            )
             await self._state.update_status(query_id, status)
             return update
         else:

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -114,9 +114,10 @@ class QueryMonitor:
                 job, status, query.start
             )
             await self._state.update_status(query_id, status)
+            logger.debug("Sending status update for running query")
             return update
         else:
             await self._arq.enqueue("handle_finished_query", query_id)
             await self._state.mark_queued_query(query_id)
-            self._logger.debug("Dispatched finished query to worker")
+            logger.info("Dispatched finished query to worker")
             return None

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -115,12 +115,12 @@ class QueryService:
         JobStatus
             Initial status of the job.
         """
+        start = datetime.now(tz=UTC)
         metadata = job.to_job_metadata()
         query_for_logging = metadata.model_dump(mode="json", exclude_none=True)
         logger = self._logger.bind(
             job_id=job.job_id, username=job.owner, query=query_for_logging
         )
-        start = datetime.now(tz=UTC)
 
         # Check that the job request is supported.
         serialization = job.result_format.format.serialization

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -142,7 +142,10 @@ class ResultProcessor:
             Job status to report to Kafka.
         """
         logger = self._logger.bind(
-            job_id=job.job_id, qserv_id=str(query_id), username=job.owner
+            job_id=job.job_id,
+            qserv_id=str(query_id),
+            username=job.owner,
+            start_time=format_datetime_for_logging(start),
         )
         try:
             status = await self._qserv.get_query_status(query_id)

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -311,9 +311,12 @@ class ResultProcessor:
         logger.info(
             "Job complete and results uploaded",
             rows=stats.rows,
-            data_size=stats.data_bytes,
+            qserv_size=status.collected_bytes,
+            encoded_size=stats.data_bytes,
             total_size=stats.total_bytes,
-            elapsed=stats.elapsed.total_seconds(),
+            elapsed=(now - start).total_seconds(),
+            qserv_elapsed=qserv_elapsed.total_seconds(),
+            result_elapsed=stats.elapsed.total_seconds(),
         )
 
         # Delete the results.

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import assert_never
 
 from faststream.kafka import KafkaBroker
+from safir.datetime import format_datetime_for_logging
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
@@ -98,6 +99,7 @@ class ResultProcessor:
             job_id=job.job_id,
             qserv_id=str(status.query_id),
             username=job.owner,
+            start_time=format_datetime_for_logging(start),
         )
         return JobStatus(
             job_id=job.job_id,
@@ -219,6 +221,7 @@ class ResultProcessor:
             job_id=job.job_id,
             qserv_id=str(status.query_id),
             username=job.owner,
+            start_time=format_datetime_for_logging(start),
             total_chunks=status.total_chunks,
             completed_chunks=status.completed_chunks,
             result_bytes=status.collected_bytes,
@@ -270,7 +273,10 @@ class ResultProcessor:
         """
         query_id = status.query_id
         logger = self._logger.bind(
-            job_id=job.job_id, qserv_id=str(query_id), username=job.owner
+            job_id=job.job_id,
+            qserv_id=str(query_id),
+            username=job.owner,
+            start_time=format_datetime_for_logging(start),
         )
         logger.debug("Processing job completion")
 
@@ -369,7 +375,10 @@ class ResultProcessor:
             Status for the query.
         """
         logger = self._logger.bind(
-            job_id=job.job_id, qserv_id=str(query_id), username=job.owner
+            job_id=job.job_id,
+            qserv_id=str(query_id),
+            username=job.owner,
+            start_time=format_datetime_for_logging(start),
         )
         now = datetime.now(tz=UTC)
         elapsed = now - start
@@ -441,6 +450,7 @@ class ResultProcessor:
             job_id=job.job_id,
             qserv_id=str(status.query_id),
             username=job.owner,
+            start_time=format_datetime_for_logging(start),
             query=metadata.model_dump(mode="json", exclude_none=True),
             status=status.model_dump(mode="json", exclude_none=True),
             total_chunks=status.total_chunks,

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime
 
 from safir.redis import PydanticRedisStorage
 from structlog.stdlib import BoundLogger
@@ -73,16 +73,7 @@ class QueryStateStore:
         job or None
             Original job request, or `None` if no such job was found.
         """
-        query = await self._storage.get(str(query_id))
-
-        # Temporary code to fix up existing job records that have no start
-        # time. This can be deleted in the 0.4.0 release or later.
-        if query and not query.start:
-            query.start = datetime.now(tz=UTC)
-            lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
-            await self._storage.store(str(query_id), query, lifetime)
-
-        return query
+        return await self._storage.get(str(query_id))
 
     async def mark_queued_query(self, query_id: int) -> None:
         """Mark a query as queued.

--- a/src/qservkafka/workers/functions/results.py
+++ b/src/qservkafka/workers/functions/results.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy.ext.asyncio import async_scoped_session
@@ -33,7 +32,7 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: int) -> None:
     processor = factory.create_result_processor()
     try:
         status = await processor.build_query_status(
-            query_id, query.job, query.start or datetime.now(tz=UTC)
+            query_id, query.job, query.start
         )
     finally:
         await session.remove()

--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -66,10 +66,6 @@ async def test_job_run(
     )
     await asyncio.sleep(1.1)
     expected["queryInfo"]["completedChunks"] = 5
-    expected["queryInfo"]["startTime"] = int(
-        async_status.query_begin.timestamp() * 1000
-    )
-    expected["timestamp"] = int(now.timestamp() * 1000)
     status_publisher.mock.assert_called_once_with(expected)
 
     now = current_datetime()
@@ -94,8 +90,6 @@ async def test_job_run(
     }
     expected["status"] = "ERROR"
     expected["queryInfo"]["completedChunks"] = 8
-    expected["queryInfo"]["endTime"] = int(now.timestamp() * 1000)
-    expected["timestamp"] = int(now.timestamp() * 1000)
     mock.assert_called_once_with(
         expected,
         config.job_status_topic,
@@ -141,11 +135,6 @@ async def test_job_results(
     await asyncio.sleep(1.1)
     with patch.object(kafka_broker, "publish") as mock:
         assert await run_arq_jobs(kafka_broker) == 1
-    expected["queryInfo"]["startTime"] = int(
-        async_status.query_begin.timestamp() * 1000
-    )
-    expected["queryInfo"]["endTime"] = int(now.timestamp() * 1000)
-    expected["timestamp"] = int(now.timestamp() * 1000)
     mock.assert_called_once_with(
         expected,
         config.job_status_topic,

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -156,13 +156,21 @@ async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
         )
     )
     status = await query_service.start_query(job)
+    now = datetime.now(tz=UTC)
     expected.execution_id = "4"
+    assert status.query_info
     expected.query_info = JobQueryInfo(
-        start_time=now, end_time=now, total_chunks=10, completed_chunks=4
+        total_chunks=10,
+        completed_chunks=4,
+        start_time=status.query_info.start_time,
+        end_time=status.query_info.end_time,
     )
     expected.error.code = JobErrorCode.backend_error
     expected.error.message = "Query failed in backend"
     assert status == expected
+    assert status.query_info.start_time <= now
+    assert status.query_info.end_time
+    assert status.query_info.end_time <= now
 
     assert await state_store.get_active_queries() == set()
 

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 from pydantic import SecretStr
 
@@ -121,12 +123,14 @@ async def test_cancel(factory: Factory) -> None:
 
     assert await state_store.get_active_queries() == {1}
 
+    now = datetime.now(tz=UTC)
     status = await query_service.cancel_query(cancel)
     assert status == canceled_status
     assert_approximately_now(status.timestamp)
     assert status.query_info
     assert status.query_info.start_time == start_time
-    assert_approximately_now(status.query_info.end_time)
+    assert status.query_info.end_time
+    assert status.query_info.end_time >= now
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix query start and end times in status responses. Previously, the start time and, for canceled or completed queries, the end time were taken directly from the Qserv query information. This includes only time spent by Qserv, which results in an inaccurate picture of the query execution time in the TAP UWS table. Instead measure query timings from the time the query was received by the bridge to when it completes uploading of the results, or is aware of a failure.