### PR TITLE
DM-51603: Simplify test data utility functions

### DIFF
--- a/tests/handlers/kafka_test.py
+++ b/tests/handlers/kafka_test.py
@@ -28,8 +28,8 @@ from qservkafka.models.qserv import AsyncQueryPhase, AsyncQueryStatus
 from ..support.arq import run_arq_jobs
 from ..support.data import (
     read_test_job_run,
+    read_test_job_run_json,
     read_test_job_status_json,
-    read_test_json,
 )
 from ..support.qserv import MockQserv
 
@@ -42,8 +42,8 @@ async def test_job_run(
     status_publisher: AsyncAPIDefaultPublisher,
     mock_qserv: MockQserv,
 ) -> None:
-    job = read_test_json("jobs/simple")
-    expected = read_test_job_status_json("status/simple-started")
+    job = read_test_job_run_json("simple")
+    expected = read_test_job_status_json("simple-started")
 
     await kafka_broker.publish(job, config.job_run_topic)
     assert status_publisher.mock
@@ -109,8 +109,8 @@ async def test_job_results(
     status_publisher: AsyncAPIDefaultPublisher,
     mock_qserv: MockQserv,
 ) -> None:
-    job = read_test_json("jobs/data")
-    expected = read_test_job_status_json("status/data-completed")
+    job = read_test_job_run_json("data")
+    expected = read_test_job_status_json("data-completed")
     assert status_publisher.mock
 
     await kafka_broker.publish(job, config.job_run_topic)
@@ -159,8 +159,8 @@ async def test_job_result_error(
     An earlier version of the Qserv Kafka bridge erroneously didn't stop
     processing when the API request failed.
     """
-    job = read_test_job_run("jobs/data")
-    job_json = read_test_json("jobs/data")
+    job = read_test_job_run("data")
+    job_json = read_test_job_run_json("data")
     assert status_publisher.mock
 
     await kafka_broker.publish(job_json, config.job_run_topic)
@@ -223,9 +223,9 @@ async def test_job_cancel(
     mock_qserv: MockQserv,
 ) -> None:
     """Test canceling a job."""
-    job = read_test_job_run("jobs/simple")
-    job_json = read_test_json("jobs/simple")
-    expected = read_test_job_status_json("status/simple-aborted")
+    job = read_test_job_run("simple")
+    job_json = read_test_job_run_json("simple")
+    expected = read_test_job_status_json("simple-aborted")
     assert status_publisher.mock
 
     await kafka_broker.publish(job_json, config.job_run_topic)
@@ -253,9 +253,9 @@ async def test_job_upload(
     mock_qserv: MockQserv,
 ) -> None:
     """Test running a job with table upload."""
-    job = read_test_job_run("jobs/upload")
-    job_json = read_test_json("jobs/upload")
-    status = read_test_job_status_json("status/upload-started")
+    job = read_test_job_run("upload")
+    job_json = read_test_job_run_json("upload")
+    status = read_test_job_status_json("upload-started")
     assert status_publisher.mock
 
     await kafka_broker.publish(job_json, config.job_run_topic)

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -23,9 +23,9 @@ from qservkafka.models.state import Query
 from ..support.arq import run_arq_jobs
 from ..support.data import (
     read_test_job_run,
+    read_test_job_run_json,
     read_test_job_status,
     read_test_job_status_json,
-    read_test_json,
 )
 from ..support.datetime import (
     assert_approximately_now,
@@ -34,29 +34,29 @@ from ..support.datetime import (
 from ..support.qserv import MockQserv
 
 
-async def start_query(kafka_broker: KafkaBroker, job_path: str) -> JobRun:
+async def start_query(kafka_broker: KafkaBroker, job: str) -> JobRun:
     """Send the Kafka message to start a query.
 
     Parameters
     ----------
     kafka_broker
         Kafka broker to use to send the message.
-    job_path
-        Path to the Kafka message to send.
+    job
+        Name of the Kafka message to send.
 
     Returns
     -------
     JobRun
         Parsed version of the Kafka message.
     """
-    job = read_test_job_run(job_path)
-    job_json = read_test_json(job_path)
+    job_model = read_test_job_run(job)
+    job_json = read_test_job_run_json(job)
     await kafka_broker.publish(job_json, config.job_run_topic)
-    return job
+    return job_model
 
 
 async def wait_for_status(
-    kafka_status_consumer: AIOKafkaConsumer, status_path: str
+    kafka_status_consumer: AIOKafkaConsumer, status: str
 ) -> JobStatus:
     """Wait for a Kafka status message and check it.
 
@@ -64,31 +64,31 @@ async def wait_for_status(
     ----------
     kafka_status_consumer
         Consumer for the Kafka status topic.
-    status_path
-        Path to the Kafka status message to expect.
+    status
+        Name to the Kafka status message to expect.
 
     Returns
     -------
     JobStatus
         Parsed Kafka status message.
     """
-    expected = read_test_job_status_json(status_path)
-    status = read_test_job_status(status_path)
+    expected = read_test_job_status_json(status)
+    status_model = read_test_job_status(status)
     raw_message = await kafka_status_consumer.getone()
     message = json.loads(raw_message.value.decode())
     assert message == expected
     timestamp = milliseconds_to_timestamp(message["timestamp"])
     assert_approximately_now(timestamp)
-    status.timestamp = timestamp
+    status_model.timestamp = timestamp
     start_time = milliseconds_to_timestamp(message["queryInfo"]["startTime"])
     assert_approximately_now(start_time)
-    assert status.query_info
-    status.query_info.start_time = start_time
+    assert status_model.query_info
+    status_model.query_info.start_time = start_time
     if message["queryInfo"].get("endTime"):
         end_time = milliseconds_to_timestamp(message["queryInfo"]["endTime"])
         assert_approximately_now(end_time)
-        status.query_info.end_time = end_time
-    return status
+        status_model.query_info.end_time = end_time
+    return status_model
 
 
 async def wait_for_dispatch(
@@ -141,10 +141,8 @@ async def test_success(
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
 
-        job = await start_query(kafka_broker, "jobs/data")
-        status = await wait_for_status(
-            kafka_status_consumer, "status/data-started"
-        )
+        job = await start_query(kafka_broker, "data")
+        status = await wait_for_status(kafka_status_consumer, "data-started")
         assert status.query_info
 
         now = datetime.now(tz=UTC)
@@ -166,7 +164,7 @@ async def test_success(
 
     # Run the background tsk queue.
     assert await run_arq_jobs() == 1
-    await wait_for_status(kafka_status_consumer, "status/data-completed")
+    await wait_for_status(kafka_status_consumer, "data-completed")
 
     # Ensure all query state has been deleted.
     redis_client = redis.get_client()
@@ -186,8 +184,8 @@ async def test_missing_executing(
     """Test queries that are not in the process list but still executing."""
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
-        await start_query(kafka_broker, "jobs/data")
-        await wait_for_status(kafka_status_consumer, "status/data-started")
+        await start_query(kafka_broker, "data")
+        await wait_for_status(kafka_status_consumer, "data-started")
 
         # Remove the query from the running query list. It should be
         # dispatched to the result worker.
@@ -197,7 +195,7 @@ async def test_missing_executing(
     # Run the backend worker. It should process the job and send the same
     # status update we already sent (since nothing has changed).
     assert await run_arq_jobs() == 1
-    await wait_for_status(kafka_status_consumer, "status/data-started")
+    await wait_for_status(kafka_status_consumer, "data-started")
 
     # The query should still be active and should no longer be marked as
     # dispatched, so it will be checked again the next time through the

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -30,7 +30,7 @@ from ..support.qserv import MockQserv
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
-    job = read_test_job_run("jobs/simple")
+    job = read_test_job_run("simple")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC)
@@ -79,7 +79,7 @@ async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
-    job = read_test_job_run("jobs/simple")
+    job = read_test_job_run("simple")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC)
@@ -181,7 +181,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC)
 
-    job = read_test_job_run("jobs/tabledata")
+    job = read_test_job_run("tabledata")
     status = await query_service.start_query(job)
     expected = JobStatus(
         job_id=job.job_id,
@@ -198,7 +198,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     assert expected.error
     assert status == expected
 
-    job = read_test_job_run("jobs/arraysize")
+    job = read_test_job_run("arraysize")
     status = await query_service.start_query(job)
     expected = JobStatus(
         job_id=job.job_id,
@@ -224,7 +224,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
 async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("jobs/data")
+    job = read_test_job_run("data")
     now = datetime.now(tz=UTC)
 
     mock_qserv.set_immediate_success(job)
@@ -259,7 +259,7 @@ async def test_upload_timeout(
     """
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("jobs/data")
+    job = read_test_job_run("data")
 
     mock_qserv.set_immediate_success(job)
     mock_qserv.set_upload_delay(timedelta(seconds=2))
@@ -288,6 +288,6 @@ async def test_upload_timeout(
 async def test_cancel_unknown(factory: Factory) -> None:
     """Test canceling an unknown job."""
     query_service = factory.create_query_service()
-    cancel = read_test_job_cancel("cancel/simple")
+    cancel = read_test_job_cancel("simple")
 
     assert await query_service.cancel_query(cancel) is None

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -52,8 +52,8 @@ async def test_success(
 
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("jobs/data")
-    expected_status = read_test_job_status("status/data-completed")
+    job = read_test_job_run("data")
+    expected_status = read_test_job_status("data-completed")
     mock_qserv.set_immediate_success(job)
 
     gc.collect()

--- a/tests/services/monitor_test.py
+++ b/tests/services/monitor_test.py
@@ -23,8 +23,8 @@ async def test_dispatch(factory: Factory, mock_qserv: MockQserv) -> None:
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     monitor = await factory.create_query_monitor()
-    job = read_test_job_run("jobs/simple")
-    expected_status = read_test_job_status("status/simple-started")
+    job = read_test_job_run("simple")
+    expected_status = read_test_job_status("simple-started")
 
     status = await query_service.start_query(job)
     assert status == expected_status

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -55,8 +55,8 @@ async def assert_query_successful(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_start(factory: Factory) -> None:
-    job = read_test_job_run("jobs/simple")
-    expected_status = read_test_job_status("status/simple-started")
+    job = read_test_job_run("simple")
+    expected_status = read_test_job_status("simple-started")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
 
@@ -76,8 +76,8 @@ async def test_start(factory: Factory) -> None:
 async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     """Test a job that completes immediately."""
     query_service = factory.create_query_service()
-    job = read_test_job_run("jobs/data")
-    expected_status = read_test_job_status("status/data-completed")
+    job = read_test_job_run("data")
+    expected_status = read_test_job_status("data-completed")
     state_store = factory.create_query_state_store()
 
     await assert_query_successful(
@@ -107,10 +107,10 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_cancel(factory: Factory) -> None:
-    job = read_test_job_run("jobs/simple")
-    started_status = read_test_job_status("status/simple-started")
-    cancel = read_test_job_cancel("cancel/simple")
-    canceled_status = read_test_job_status("status/simple-aborted")
+    job = read_test_job_run("simple")
+    started_status = read_test_job_status("simple-started")
+    cancel = read_test_job_cancel("simple")
+    canceled_status = read_test_job_status("simple-aborted")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
 
@@ -139,8 +139,8 @@ async def test_cancel(factory: Factory) -> None:
 )
 async def test_maxrec(factory: Factory, mock_qserv: MockQserv) -> None:
     query_service = factory.create_query_service()
-    job = read_test_job_run("jobs/data-maxrec")
-    expected_status = read_test_job_status("status/data-maxrec-completed")
+    job = read_test_job_run("data-maxrec")
+    expected_status = read_test_job_status("data-maxrec-completed")
 
     await assert_query_successful(
         query_service=query_service,
@@ -157,8 +157,8 @@ async def test_maxrec(factory: Factory, mock_qserv: MockQserv) -> None:
 async def test_maxrec_zero(factory: Factory, mock_qserv: MockQserv) -> None:
     """Test a query with MAXREC set to zero."""
     query_service = factory.create_query_service()
-    job = read_test_job_run("jobs/data-zero")
-    expected_status = read_test_job_status("status/data-zero-completed")
+    job = read_test_job_run("data-zero")
+    expected_status = read_test_job_status("data-zero-completed")
 
     await assert_query_successful(
         query_service=query_service,
@@ -178,8 +178,8 @@ async def test_no_api_version(
     """Test disabling sending the API version in Qserv requests."""
     monkeypatch.setattr(config, "qserv_rest_send_api_version", False)
     query_service = factory.create_query_service()
-    job = read_test_job_run("jobs/data")
-    expected_status = read_test_job_status("status/data-completed")
+    job = read_test_job_run("data")
+    expected_status = read_test_job_status("data-completed")
     state_store = factory.create_query_state_store()
 
     await assert_query_successful(
@@ -191,8 +191,8 @@ async def test_no_api_version(
 
     # Also test starting a job with table upload, since that tests an
     # additional API endpoint.
-    job = read_test_job_run("jobs/upload")
-    expected_status = read_test_job_status("status/upload-started")
+    job = read_test_job_run("upload")
+    expected_status = read_test_job_status("upload-started")
     expected_status.execution_id = "2"
 
     mock_qserv.set_immediate_success(None)
@@ -217,8 +217,8 @@ async def test_auth(
     monkeypatch.setattr(config, "qserv_rest_password", SecretStr("password"))
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("jobs/data")
-    expected_status = read_test_job_status("status/data-completed")
+    job = read_test_job_run("data")
+    expected_status = read_test_job_status("data-completed")
 
     await assert_query_successful(
         query_service=query_service,
@@ -229,8 +229,8 @@ async def test_auth(
 
     # Also test starting a job with table upload, since that tests an
     # additional API endpoint.
-    job = read_test_job_run("jobs/upload")
-    expected_status = read_test_job_status("status/upload-started")
+    job = read_test_job_run("upload")
+    expected_status = read_test_job_status("upload-started")
     expected_status.execution_id = "2"
 
     mock_qserv.set_immediate_success(None)
@@ -251,9 +251,9 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
     """Test temporary table upload."""
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("jobs/upload")
-    completed_status = read_test_job_status("status/upload-completed")
-    started_status = read_test_job_status("status/upload-started")
+    job = read_test_job_run("upload")
+    completed_status = read_test_job_status("upload-completed")
+    started_status = read_test_job_status("upload-started")
 
     await assert_query_successful(
         query_service=query_service,

--- a/tests/storage/qserv_test.py
+++ b/tests/storage/qserv_test.py
@@ -19,8 +19,8 @@ async def test_list_running_queries(
 ) -> None:
     qserv = factory.create_qserv_client()
     query_service = factory.create_query_service()
-    job = read_test_job_run("jobs/simple")
-    expected_status = read_test_job_status("status/simple-started")
+    job = read_test_job_run("simple")
+    expected_status = read_test_job_status("simple-started")
 
     processes = await qserv.list_running_queries()
     assert processes == {}

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -66,7 +66,7 @@ def read_test_job_cancel(filename: str) -> JobCancel:
     Parameters
     ----------
     filename
-        File to read relative to the test data directory, without the
+        File to read relative to the test cancel directory, without the
         ``.json`` suffix.
 
     Returns
@@ -74,7 +74,7 @@ def read_test_job_cancel(filename: str) -> JobCancel:
     JobCancel
         Parsed contents of the file.
     """
-    return JobCancel.model_validate(read_test_json(filename))
+    return JobCancel.model_validate(read_test_json(f"cancel/{filename}"))
 
 
 def read_test_job_run(filename: str) -> JobRun:
@@ -83,7 +83,7 @@ def read_test_job_run(filename: str) -> JobRun:
     Parameters
     ----------
     filename
-        File to read relative to the test data directory, without the
+        File to read relative to the test jobs directory, without the
         ``.json`` suffix.
 
     Returns
@@ -91,7 +91,24 @@ def read_test_job_run(filename: str) -> JobRun:
     JobRun
         Parsed contents of the file.
     """
-    return JobRun.model_validate(read_test_json(filename))
+    return JobRun.model_validate(read_test_json(f"jobs/{filename}"))
+
+
+def read_test_job_run_json(filename: str) -> JobRun:
+    """Read test data parsed as JSON to run a query.
+
+    Parameters
+    ----------
+    filename
+        File to read relative to the test jobs directory, without the
+        ``.json`` suffix.
+
+    Returns
+    -------
+    JobRun
+        Parsed contents of the file.
+    """
+    return read_test_json(f"jobs/{filename}")
 
 
 def read_test_job_status(filename: str) -> JobStatus:
@@ -100,7 +117,7 @@ def read_test_job_status(filename: str) -> JobStatus:
     Parameters
     ----------
     filename
-        File to read relative to the test data directory, without the
+        File to read relative to the test status directory, without the
         ``.json`` suffix.
 
     Returns
@@ -108,7 +125,7 @@ def read_test_job_status(filename: str) -> JobStatus:
     JobStatus
         Parsed contents of the file.
     """
-    result = JobStatus.model_validate(read_test_json(filename))
+    result = JobStatus.model_validate(read_test_json(f"status/{filename}"))
     result.timestamp = ANY
     if result.query_info:
         result.query_info.start_time = ANY
@@ -123,7 +140,7 @@ def read_test_job_status_json(filename: str) -> dict[str, Any]:
     Parameters
     ----------
     filename
-        File to read relative to the test data directory, without the
+        File to read relative to the test status directory, without the
         ``.json`` suffix.
 
     Returns
@@ -131,8 +148,8 @@ def read_test_job_status_json(filename: str) -> dict[str, Any]:
     JobStatus
         Parsed contents of the file.
     """
-    result_model = JobStatus.model_validate(read_test_json(filename))
-    result = result_model.model_dump(mode="json")
+    model = JobStatus.model_validate(read_test_json(f"status/{filename}"))
+    result = model.model_dump(mode="json")
     result["timestamp"] = ANY
     if "queryInfo" in result:
         result["queryInfo"]["startTime"] = ANY

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -586,7 +586,7 @@ class MockQserv:
         body.close()
 
         # Check the request is correct.
-        expected_job = read_test_job_run("jobs/upload")
+        expected_job = read_test_job_run("upload")
         upload_table = expected_job.upload_tables[0]
         expected = {
             "database": upload_table.table_name.split(".", 1)[0],
@@ -678,7 +678,7 @@ async def register_mock_qserv(
     regex = rf"{base}/query-async/status/(?P<query_id>[0-9]+)"
     respx_mock.get(url__regex=regex).mock(side_effect=mock.status)
 
-    upload_job = read_test_job_run("jobs/upload")
+    upload_job = read_test_job_run("upload")
     for upload_table in upload_job.upload_tables:
         url = upload_table.source_url
         respx_mock.get(url).mock(side_effect=mock.get_upload_source)


### PR DESCRIPTION
Assume the correct path prefix when loading test data and remove the explicit path prefixes from all of the calls in individual tests. Add a new function for loading the job run message as JSON for use when posting a Kafka message (possibly mocked).