### PR TITLE
DM-51603: Move more tests into real Kafka tests

### DIFF
--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -338,7 +338,7 @@ class ResultProcessor:
         return JobStatus(
             job_id=job.job_id,
             execution_id=str(query_id),
-            timestamp=status.last_update or datetime.now(tz=UTC),
+            timestamp=datetime.now(tz=UTC),
             status=ExecutionPhase.COMPLETED,
             query_info=JobQueryInfo.from_query_status(
                 status, start, finished=True

--- a/tests/data/status/simple-failed.json
+++ b/tests/data/status/simple-failed.json
@@ -1,0 +1,19 @@
+{
+  "job_id": "uws123",
+  "execution_id": "1",
+  "timestamp": 1743540791,
+  "status": "ERROR",
+  "error": {
+    "code": "backend_error",
+    "message": "Query failed in backend"
+  },
+  "query_info": {
+    "start_time": 1743540791,
+    "total_chunks": 10,
+    "completed_chunks": 8
+  },
+  "metadata": {
+    "query": "SELECT TOP 10 * FROM table",
+    "database": "dp1"
+  }
+}

--- a/tests/data/status/simple-partial.json
+++ b/tests/data/status/simple-partial.json
@@ -1,0 +1,15 @@
+{
+  "job_id": "uws123",
+  "execution_id": "1",
+  "timestamp": 1743540791,
+  "status": "EXECUTING",
+  "query_info": {
+    "start_time": 1743540791,
+    "total_chunks": 10,
+    "completed_chunks": 5
+  },
+  "metadata": {
+    "query": "SELECT TOP 10 * FROM table",
+    "database": "dp1"
+  }
+}


### PR DESCRIPTION
Start the process of slowly moving all full end-to-end tests to use a real Kafka instead of fighting with mocks and their limitations by moving the basic success and failure tests into that framework.