### PR TITLE
DM-51834: Add support for unicodeChar fields in the binary2 encoding

### DIFF
--- a/changelog.d/20250718_184044_steliosvoutsinas_DM_51834.md
+++ b/changelog.d/20250718_184044_steliosvoutsinas_DM_51834.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Added support for encoding unicodeChar fields

--- a/src/qservkafka/models/votable.py
+++ b/src/qservkafka/models/votable.py
@@ -90,7 +90,8 @@ class VOTablePrimitive(Enum):
     """
 
     boolean = ("boolean", "1s")
-    char = ("char", "s")
+    char = ("char", "c")
+    unicode_char = ("unicodeChar", "2s")
     double = ("double", ">d")
     float = ("float", ">f")
     short = ("short", ">h")
@@ -125,6 +126,12 @@ class VOTablePrimitive(Enum):
             case "char":
                 if not isinstance(value, bytes):
                     value = str(value).encode()
+                return struct.pack(
+                    self._pack_format, value[:1] if value else b"\x00"
+                )
+            case "unicodeChar":
+                if not isinstance(value, bytes):
+                    value = str(value).encode("utf-16-be")
                 return struct.pack(self._pack_format, value)
             case "double" | "float":
                 value = math.nan if value is None else float(value)
@@ -134,3 +141,7 @@ class VOTablePrimitive(Enum):
                 return struct.pack(self._pack_format, value)
             case _:  # pragma: no cover
                 raise ValueError(f"Unknown type {self.value}")
+
+    def is_string(self) -> bool:
+        """Check if the primitive type is a string type."""
+        return self in (VOTablePrimitive.char, VOTablePrimitive.unicode_char)

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -21,7 +21,6 @@ from ..models.kafka import (
     JobRun,
     JobStatus,
 )
-from ..models.votable import VOTablePrimitive
 from ..storage.gafaelfawr import GafaelfawrClient
 from ..storage.qserv import QservClient
 from ..storage.rate import RateLimitStore
@@ -138,9 +137,13 @@ class QueryService:
             msg = f"{serialization} serialization not supported"
             return self._build_invalid_request_status(job, msg)
         for column in job.result_format.column_types:
-            is_char = column.datatype == VOTablePrimitive.char
-            if not is_char and column.arraysize is not None:
-                msg = "arraysize only supported for char fields"
+            if (
+                not column.datatype.is_string()
+                and column.arraysize is not None
+            ):
+                msg = (
+                    "arraysize only supported for char and unicodeChar fields"
+                )
                 return self._build_invalid_request_status(job, msg)
 
         # Increment the user's running queries and make sure they have space

--- a/tests/models/votable_test.py
+++ b/tests/models/votable_test.py
@@ -42,3 +42,36 @@ def test_votable_primitive() -> None:
     assert model.type == VOTablePrimitive.double
     assert model.type.pack(13.71) == struct.pack(">d", 13.71)
     assert model.model_dump(mode="json") == {"type": "double"}
+
+
+def test_votable_primitive_unicode_char() -> None:
+    class TestModel(BaseModel):
+        type: VOTablePrimitive
+
+    model = TestModel.model_validate({"type": "unicodeChar"})
+    assert model.type == VOTablePrimitive.unicode_char
+    assert model.model_dump(mode="json") == {"type": "unicodeChar"}
+
+    result = model.type.pack("h")
+    expected = "h".encode("utf-16-be")
+    assert result == expected
+
+    result = model.type.pack("hello")
+    expected = "h".encode("utf-16-be")
+    assert result == expected
+
+
+def test_votable_primitive_char_vs_unicode_char() -> None:
+    char_type = VOTablePrimitive.char
+    unicode_type = VOTablePrimitive.unicode_char
+
+    test_char = "h"
+
+    char_result = char_type.pack(test_char)
+    unicode_result = unicode_type.pack(test_char)
+
+    assert char_result == struct.pack("c", test_char.encode()[:1])
+    assert unicode_result == test_char.encode("utf-16-be")
+
+    assert char_type.pack("hello") == b"h"
+    assert unicode_type.pack("hello") == b"\x00h"

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -207,7 +207,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
         status=ExecutionPhase.ERROR,
         error=JobError(
             code=JobErrorCode.invalid_request,
-            message="arraysize only supported for char fields",
+            message="arraysize only supported for char and unicodeChar fields",
         ),
         metadata=job.to_job_metadata(),
     )

--- a/tests/storage/votable_test.py
+++ b/tests/storage/votable_test.py
@@ -76,3 +76,154 @@ async def test_type_encoder() -> None:
     ]
     for column, data, expected in tests:
         await assert_encoded_value(column, data, expected)
+
+
+@pytest.mark.asyncio
+async def test_unicode_char_variable_arrays() -> None:
+    tests = [
+        (
+            {"name": "text", "datatype": "unicodeChar", "arraysize": "*"},
+            "hello",
+            b"\x00\x00\x00\x00\x05\x00h\x00e\x00l\x00l\x00o",
+        ),
+        (
+            {"name": "text", "datatype": "unicodeChar", "arraysize": "*"},
+            "",
+            b"\x00\x00\x00\x00\x00",
+        ),
+        (
+            {"name": "emoji", "datatype": "unicodeChar", "arraysize": "*"},
+            "😀",
+            b"\x00\x00\x00\x00\x02\xd8=\xde\x00",
+        ),
+        (
+            {"name": "accents", "datatype": "unicodeChar", "arraysize": "*"},
+            "café",
+            b"\x00\x00\x00\x00\x04\x00c\x00a\x00f\x00\xe9",
+        ),
+    ]
+
+    for column, data, expected in tests:
+        await assert_encoded_value(column, data, expected)
+
+
+@pytest.mark.asyncio
+async def test_unicode_char_fixed_arrays() -> None:
+    tests = [
+        (
+            {"name": "short", "datatype": "unicodeChar", "arraysize": "5"},
+            "hi",
+            b"\x00\x00h\x00i\x00\x00\x00\x00\x00\x00",
+        ),
+        (
+            {"name": "exact", "datatype": "unicodeChar", "arraysize": "3"},
+            "abc",
+            b"\x00\x00a\x00b\x00c",
+        ),
+        (
+            {"name": "long", "datatype": "unicodeChar", "arraysize": "3"},
+            "hello",
+            b"\x00\x00h\x00e\x00l",
+        ),
+        (
+            {"name": "empty", "datatype": "unicodeChar", "arraysize": "2"},
+            "",
+            b"\x00\x00\x00\x00\x00",
+        ),
+        (
+            {"name": "single", "datatype": "unicodeChar", "arraysize": "3"},
+            "A",
+            b"\x00\x00A\x00\x00\x00\x00",
+        ),
+        (
+            {
+                "name": "split_surrogate",
+                "datatype": "unicodeChar",
+                "arraysize": "3",
+            },
+            "AB😀",
+            b"\x00\x00A\x00B\x00\x00",
+        ),
+        (
+            {
+                "name": "emoji_too_big",
+                "datatype": "unicodeChar",
+                "arraysize": "1",
+            },
+            "😀",
+            b"\x00\x00\x00",
+        ),
+    ]
+
+    for column, data, expected in tests:
+        await assert_encoded_value(column, data, expected)
+
+
+@pytest.mark.asyncio
+async def test_unicode_char_bounded_variable_arrays() -> None:
+    tests = [
+        (
+            {"name": "short", "datatype": "unicodeChar", "arraysize": "5*"},
+            "hi",
+            b"\x00\x00\x00\x00\x02\x00h\x00i",
+        ),
+        (
+            {"name": "exact", "datatype": "unicodeChar", "arraysize": "3*"},
+            "abc",
+            b"\x00\x00\x00\x00\x03\x00a\x00b\x00c",
+        ),
+        (
+            {
+                "name": "truncated",
+                "datatype": "unicodeChar",
+                "arraysize": "3*",
+            },
+            "hello world",
+            b"\x00\x00\x00\x00\x03\x00h\x00e\x00l",
+        ),
+        (
+            {"name": "empty", "datatype": "unicodeChar", "arraysize": "5*"},
+            "",
+            b"\x00\x00\x00\x00\x00",
+        ),
+        (
+            {
+                "name": "emoji_byte_limit",
+                "datatype": "unicodeChar",
+                "arraysize": "1*",
+            },
+            "😀",
+            b"\x00\x00\x00\x00\x00",
+        ),
+    ]
+
+    for column, data, expected in tests:
+        await assert_encoded_value(column, data, expected)
+
+
+@pytest.mark.asyncio
+async def test_unicode_char_surrogate_pair_truncation() -> None:
+    tests = [
+        (
+            {"name": "safe", "datatype": "unicodeChar", "arraysize": "2"},
+            "AB😀C",
+            b"\x00\x00A\x00B",
+        ),
+        (
+            {"name": "safe_var", "datatype": "unicodeChar", "arraysize": "2*"},
+            "AB😀C",
+            b"\x00\x00\x00\x00\x02\x00A\x00B",
+        ),
+        (
+            {
+                "name": "emoji_var",
+                "datatype": "unicodeChar",
+                "arraysize": "1*",
+            },
+            "😀",
+            b"\x00\x00\x00\x00\x00",
+        ),
+    ]
+
+    for column, data, expected in tests:
+        await assert_encoded_value(column, data, expected)


### PR DESCRIPTION
# Summary
Changes to support encoding `unicodeChar` in the binary2 encoder.

The motivation for this is that astropy as it is currently will set the type for string fields (uploaded as CSV) to `unicodeChar`.
This leads to an inconsistency between what our TAP service advertises as the datatype for the field (char) and what the uploaded table from Astropy has (`unicodeChar`).

## Notebook
The following notebook reproduces the problem:
https://github.com/lsst/cst-dev/blob/main/MLG_sandbox/DP1/300_Science_Demos/306_Extragalactic_transients/ut_fail_string_column.ipynb

## Tests
- Added a couple of unit tests
- Tested running an TAP Upload query with the csv data from the above notebook which now completes successfully.
- I've also ran taplint via https://github.com/stvoutsin/rspvalidator and this completes successfully

## Follow-up tasks
Follow-up tasks would probably include looking into whether astropy should be instead using `char` as the type which will require upstream (astropy) issue/PR iterations.

The supporting changes for the TAP service are here:
https://github.com/lsst-sqre/lsst-tap-service/pull/164