### PR TITLE
DM-51889: Add TAP query ID to metrics events

### DIFF
--- a/changelog.d/20250721_144711_rra_DM_51889.md
+++ b/changelog.d/20250721_144711_rra_DM_51889.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Add the TAP query ID to all metrics events.

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -42,6 +42,11 @@ class QservFailureEvent(EventPayload):
 class BaseQueryEvent(EventPayload):
     """Common fields in all query events."""
 
+    job_id: str = Field(
+        title="UWS job ID",
+        description="Identifier of job in the TAP server's UWS database",
+    )
+
     username: str = Field(
         ..., title="Username", description="Username of authenticated user"
     )

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -266,7 +266,7 @@ class QueryService:
                 size = await self._qserv.upload_table(upload)
                 logger.info("Uploaded table", table_name=upload.table_name)
                 event = TemporaryTableUploadEvent(
-                    username=job.owner, size=size
+                    job_id=job.job_id, username=job.owner, size=size
                 )
                 await self._events.temporary_table.publish(event)
         except (QservApiError, TableUploadWebError) as e:

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -236,7 +236,9 @@ class ResultProcessor:
             result_bytes=status.collected_bytes,
         )
         timestamp = status.last_update or datetime.now(tz=UTC)
-        event = QueryAbortEvent(username=job.owner, elapsed=timestamp - start)
+        event = QueryAbortEvent(
+            job_id=job.job_id, username=job.owner, elapsed=timestamp - start
+        )
         await self._events.query_abort.publish(event)
         return JobStatus(
             job_id=job.job_id,
@@ -308,6 +310,7 @@ class ResultProcessor:
         else:
             qserv_rate = None
         event = QuerySuccessEvent(
+            job_id=job.job_id,
             username=job.owner,
             elapsed=now - start,
             qserv_elapsed=qserv_elapsed,
@@ -417,7 +420,10 @@ class ResultProcessor:
 
         # Send a metrics event for the failure.
         event = QueryFailureEvent(
-            username=job.owner, error=error.code, elapsed=elapsed
+            job_id=job.job_id,
+            username=job.owner,
+            error=error.code,
+            elapsed=elapsed,
         )
         await self._events.query_failure.publish(event)
 
@@ -467,6 +473,7 @@ class ResultProcessor:
             result_bytes=status.collected_bytes,
         )
         event = QueryFailureEvent(
+            job_id=job.job_id,
             username=job.owner,
             error=JobErrorCode.backend_error,
             elapsed=datetime.now(tz=UTC) - start,


### PR DESCRIPTION
Add the TAP query ID to all metrics events to make it easier to correlate metrics events with specific queries.