### PR TITLE
DM-51889: Include elapsed time in table upload metrics events

### DIFF
--- a/changelog.d/20250721_153024_rra_DM_51889.md
+++ b/changelog.d/20250721_153024_rra_DM_51889.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Include the elapsed time required to upload the table to Qserv in metrics events for successful user table uploads. This does not include the time required to retrieve the table from its source URLs before upload.

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -178,6 +178,15 @@ class TemporaryTableUploadEvent(BaseQueryEvent):
         description="Size of the CSV file holding the table data",
     )
 
+    elapsed: timedelta = Field(
+        ...,
+        title="Upload time (seconds)",
+        description=(
+            "Time required to upload the table to Qserv. This does not include"
+            " the time required to read the table from GCS."
+        ),
+    )
+
 
 class Events(EventMaker):
     """Event publishers for all possible events, used by workers and frontend.

--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import timedelta
 from enum import StrEnum
 from typing import Annotated, Any
 
@@ -15,6 +17,7 @@ __all__ = [
     "AsyncSubmitRequest",
     "AsyncSubmitResponse",
     "BaseResponse",
+    "TableUploadStats",
 ]
 
 
@@ -119,3 +122,18 @@ class AsyncSubmitResponse(BaseResponse):
             validation_alias="queryId",
         ),
     ]
+
+
+@dataclass
+class TableUploadStats:
+    """Statistics from a table upload to Qserv."""
+
+    size: int
+    """Size of the uploaded table in CSV format (bytes)."""
+
+    elapsed: timedelta
+    """Time required to upload the table to Qserv.
+
+    Does not include the time required to retrieve the table source and SQL
+    from GCS before uploading.
+    """

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -263,10 +263,13 @@ class QueryService:
         # Upload any tables.
         try:
             for upload in job.upload_tables:
-                size = await self._qserv.upload_table(upload)
+                stats = await self._qserv.upload_table(upload)
                 logger.info("Uploaded table", table_name=upload.table_name)
                 event = TemporaryTableUploadEvent(
-                    job_id=job.job_id, username=job.owner, size=size
+                    job_id=job.job_id,
+                    username=job.owner,
+                    size=stats.size,
+                    elapsed=stats.elapsed,
                 )
                 await self._events.temporary_table.publish(event)
         except (QservApiError, TableUploadWebError) as e:


### PR DESCRIPTION
Include the elapsed time required to upload the table to Qserv in metrics events for successful user table uploads. This does not include the time required to retrieve the table from its source URLs before upload.