### PR TITLE
DM-51889: Tweak timeout and shield result shutdown

### DIFF
--- a/changelog.d/20250721_154604_rra_DM_51889.md
+++ b/changelog.d/20250721_154604_rra_DM_51889.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Increase termination grace period for arq workers and shield closing the database query results. This hopefully will fix an issue where arq's attempt to cancel a timed-out task converted the cancellation exception to a SQL exception, which triggered a retry of the query in one worker while simultaneously processing the query in a second worker.

--- a/src/qservkafka/constants.py
+++ b/src/qservkafka/constants.py
@@ -19,7 +19,7 @@ __all__ = [
     "UPLOAD_BUFFER_SIZE",
 ]
 
-ARQ_TIMEOUT_GRACE = timedelta(seconds=2)
+ARQ_TIMEOUT_GRACE = timedelta(seconds=5)
 """Additional grace period to allow on top of result processing timeout.
 
 This should be long enough to allow for asking the REST API for the status,

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import struct
 from binascii import b2a_base64
 from collections.abc import AsyncGenerator
@@ -116,7 +117,7 @@ class VOTableEncoder:
             yield self._base64_encode_bytes(encoded, last=True)
         finally:
             encoded.close()
-            await results.aclose()
+            await asyncio.shield(results.aclose())
 
         # Add the footer, which varies if the results overflowed.
         if overflow:


### PR DESCRIPTION
Increase the grace period between when we try to kill result upload that is taking too long and when arq kills the worker, since we saw one case of a failure to shut down cleanly before arq cancelled the worker. Shield the close of the result generator that is reading from MySQL so that even if we lose that raise, hopefully the SQL shutdown will not get cancelled in a way that results in a spurious error and thus triggers a retry.