### PR TITLE
DM-51603: Use internal models to simplify APIs

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -29,7 +29,7 @@ from .constants import (
     REDIS_TIMEOUT,
 )
 from .events import Events
-from .models.state import Query
+from .models.state import RunningQuery
 from .services.monitor import QueryMonitor
 from .services.query import QueryService
 from .services.results import ResultProcessor
@@ -215,7 +215,9 @@ class Factory:
             Client for query state.
         """
         redis_storage = PydanticRedisStorage(
-            datatype=Query, redis=self._context.redis, key_prefix="query:"
+            datatype=RunningQuery,
+            redis=self._context.redis,
+            key_prefix="query:",
         )
         return QueryStateStore(redis_storage, self._logger)
 

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import BaseModel, Field
 
 from .kafka import JobRun
 from .qserv import AsyncQueryStatus
 
-__all__ = ["Query"]
+__all__ = [
+    "Query",
+    "RunningQuery",
+]
 
 
 class Query(BaseModel):
-    """Represents a running Qserv query."""
+    """Represents a started Qserv query with no Qserv status."""
 
     query_id: Annotated[int, Field(title="Qserv ID of query")]
 
@@ -22,10 +25,36 @@ class Query(BaseModel):
 
     job: Annotated[JobRun, Field(title="Full job request")]
 
-    status: Annotated[
-        AsyncQueryStatus | None, Field(title="Last known status")
-    ]
+
+class RunningQuery(Query):
+    """Represents a running Qserv query with a known status."""
+
+    status: Annotated[AsyncQueryStatus, Field(title="Last known status")]
 
     result_queued: Annotated[
         bool, Field(title="Whether queued for result procesing")
     ]
+
+    @classmethod
+    def from_query(cls, query: Query, status: AsyncQueryStatus) -> Self:
+        """Convert a started query to full query state by recording status.
+
+        Parameters
+        ----------
+        query
+            Query with no status.
+        status
+            Initial status of query.
+
+        Returns
+        -------
+        Query
+            Query state.
+        """
+        return cls(
+            query_id=query.query_id,
+            start=query.start,
+            job=query.job,
+            status=status,
+            result_queued=False,
+        )

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -21,6 +21,7 @@ from ..models.kafka import (
     JobRun,
     JobStatus,
 )
+from ..models.state import Query
 from ..storage.gafaelfawr import GafaelfawrClient
 from ..storage.qserv import QservClient
 from ..storage.rate import RateLimitStore
@@ -109,11 +110,7 @@ class QueryService:
             return None
 
         # Return an appropriate status update for the job's current status.
-        return await self._results.build_query_status(
-            query_id,
-            query.job,
-            query.start or datetime.now(tz=UTC),
-        )
+        return await self._results.build_query_status(query)
 
     async def start_query(self, job: JobRun) -> JobStatus:
         """Start a new query and return its initial status.
@@ -313,6 +310,5 @@ class QueryService:
         logger.info("Started query", qserv_id=str(query_id))
 
         # Analyze the initial status and return it.
-        return await self._results.build_query_status(
-            query_id, job, start, initial=True
-        )
+        query = Query(query_id=query_id, job=job, start=start)
+        return await self._results.build_query_status(query, initial=True)

--- a/src/qservkafka/workers/functions/results.py
+++ b/src/qservkafka/workers/functions/results.py
@@ -31,16 +31,14 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: int) -> None:
         return
     processor = factory.create_result_processor()
     try:
-        status = await processor.build_query_status(
-            query_id, query.job, query.start
-        )
+        status = await processor.build_query_status(query)
     finally:
         await session.remove()
     if status.status == ExecutionPhase.EXECUTING:
         logger.warning(
             "Apparently completed job still executing",
             job_id=query.job.job_id,
-            qserv_id=str(query_id),
+            qserv_id=str(query.query_id),
             username=query.job.owner,
             status=status.model_dump(mode="json", exclude_none=True),
         )

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -21,7 +21,7 @@ from qservkafka.factory import Factory
 from qservkafka.models.gafaelfawr import GafaelfawrQuota, GafaelfawrTapQuota
 from qservkafka.models.kafka import JobRun, JobStatus
 from qservkafka.models.qserv import AsyncQueryPhase, AsyncQueryStatus
-from qservkafka.models.state import Query
+from qservkafka.models.state import RunningQuery
 
 from ..support.arq import run_arq_jobs
 from ..support.data import (
@@ -345,7 +345,7 @@ async def test_missing_executing(
     redis_client = redis.get_client()
     raw_query = redis_client.get("query:1")
     assert raw_query
-    query = Query.model_validate(json.loads(raw_query))
+    query = RunningQuery.model_validate(json.loads(raw_query))
     assert not query.result_queued
 
 


### PR DESCRIPTION
Create a new `Query` model that represents a query without a Qserv status, and rename the existing `Query` model to `RunningQuery`. The latter is what's stored in Redis. Simplify a bunch of APIs to take these models as arguments instead of a bunch of individual parameters.