### PR TITLE
DM-51603: Simplify helper to create JobQueryInfo

### DIFF
--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Annotated, Self
+from typing import Annotated
 
 from pydantic import (
     BaseModel,
@@ -17,7 +17,6 @@ from pydantic import (
 from safir.pydantic import SecondsTimedelta
 from vo_models.uws.types import ExecutionPhase
 
-from .qserv import AsyncQueryStatus
 from .votable import VOTableArraySize, VOTablePrimitive
 
 type DatetimeMillis = Annotated[
@@ -419,39 +418,6 @@ class JobQueryInfo(BaseModel):
             serialization_alias="completedChunks",
         ),
     ]
-
-    @classmethod
-    def from_query_status(
-        cls,
-        status: AsyncQueryStatus,
-        start: datetime,
-        *,
-        finished: bool = False,
-    ) -> Self:
-        """Create a new object from the query status returned by Qserv.
-
-        Parameters
-        ----------
-        status
-            Query status to convert.
-        start
-            Start time of query, measured from the point at which the Qserv
-            Kafka bridge received the query.
-        finished
-            Whether the query is finished and therefore the end time should be
-            set to now.
-
-        Returns
-        -------
-        JobQueryInfo
-            Corresponding query information.
-        """
-        return cls(
-            start_time=start,
-            total_chunks=status.total_chunks,
-            completed_chunks=status.completed_chunks,
-            end_time=datetime.now(tz=UTC) if finished else None,
-        )
 
 
 class JobResultInfo(BaseModel):

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any, Self
 
 from pydantic import BaseModel, Field
 from safir.datetime import format_datetime_for_logging
 
-from .kafka import JobRun
+from .kafka import JobQueryInfo, JobRun
 from .qserv import AsyncQueryStatus
 
 __all__ = [
@@ -67,4 +67,25 @@ class RunningQuery(Query):
             job=query.job,
             status=status,
             result_queued=False,
+        )
+
+    def to_job_query_info(self, *, finished: bool = False) -> JobQueryInfo:
+        """Build job query information based on query status.
+
+        Parameters
+        ----------
+        finished
+            Whether the query is finished and therefore the end time should be
+            set to now.
+
+        Returns
+        -------
+        JobQueryInfo
+            Corresponding query information.
+        """
+        return JobQueryInfo(
+            start_time=self.start,
+            total_chunks=self.status.total_chunks,
+            completed_chunks=self.status.completed_chunks,
+            end_time=datetime.now(tz=UTC) if finished else None,
         )


### PR DESCRIPTION
Rather than an additional constructor for `JobQueryInfo`, now that we're using the `RunningQuery` model everywhere, add a method on that object that builds the `JobQueryInfo` model directly.