### PR TITLE
DM-51603: Improve testing of flaky Qserv API

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -202,6 +202,11 @@ class Factory:
         self._logger = logger
 
     @property
+    def events(self) -> Events:
+        """Global shared metrics events publishers, used by the test suite."""
+        return self._context.events
+
+    @property
     def gafaelfawr_client(self) -> GafaelfawrClient:
         """Global shared caching Gafaelfawr client."""
         return self._context.gafaelfawr_client

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -151,6 +151,9 @@ async def wait_for_dispatch(
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_success(
     *,
     app: FastAPI,

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -107,6 +107,11 @@ class MockQserv:
         Router for HTTP mocks.
     flaky
         Whether to fail every other request.
+
+    Attributes
+    ----------
+    flaky
+        Whether Qserv API requests intermittently fail.
     """
 
     _UPLOAD_CSV = "one\ntwo\n"
@@ -122,12 +127,14 @@ class MockQserv:
         *,
         flaky: bool = False,
     ) -> None:
+        self.flaky = flaky
+
         self._session = session
         self._respx_mock = respx_mock
 
         self._expected_job: JobRun | None
         self._immediate_success: JobRun | None
-        self._intermittent_failure: int | None = 0 if flaky else None
+        self._intermittent_failure: int | None
         self._mocks: list[MagicMock] = []
         self._next_query_id: int
         self._override_status: Response | None
@@ -202,7 +209,7 @@ class MockQserv:
         """Reset the mock to its initial state."""
         self._expected_job = None
         self._immediate_success = None
-        self._intermittent_failure = None
+        self._intermittent_failure = 0 if self.flaky else None
         self._next_query_id = 1
         self._override_status = None
         self._override_submit = None
@@ -630,7 +637,7 @@ class MockQserv:
         """Check whether to return an intermittent failure."""
         if self._intermittent_failure is not None:
             self._intermittent_failure += 1
-            return self._intermittent_failure % 2 == 0
+            return self._intermittent_failure % 2 == 1
         else:
             return False
 


### PR DESCRIPTION
Add a test that retried failures from the Qserv API log metrics events. Enable testing with simulated flaky Qserv for one of the end-to-end Kafka tests as well.

Fix an initialization problem that caused the testing of a flaky Qserv REST API to be disabled. Previously, back to the refactoring of the Qserv mock, only flaky SQL connections were being tested.

Fix data leakage from the memory leak test into subsequent tests by correctly using monkeypatch to change global state instead of setting it directly. Move the disabling of the mock metrics publisher into a test-specific fixture.