### PR TITLE
DM-51603: Add tests for query success metrics events

### DIFF
--- a/changelog.d/20250728_175358_rra_DM_51603.md
+++ b/changelog.d/20250728_175358_rra_DM_51603.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fixed the `encoded_size` field of success metrics events to track the result size after base64 encoding, not before.

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -91,7 +91,7 @@ class QuerySuccessEvent(BaseQueryEvent):
     encoded_size: int = Field(
         ...,
         title="Encoded data size",
-        description="Encoded data size in bytes",
+        description="Encoded data size, after base64 encoding, in bytes",
     )
 
     result_size: int = Field(

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -106,7 +106,6 @@ class VOTableEncoder:
                     break
                 encoded_row = self._encode_row(self._config.column_types, row)
                 self._total_rows += 1
-                self._encoded_size += len(encoded_row)
                 encoded.write(encoded_row)
                 if self._total_rows % 100000 == 0:
                     self._logger.debug(f"Processed {self._total_rows} rows")
@@ -169,6 +168,7 @@ class VOTableEncoder:
             view.release()
             binary.seek(0)
             binary.write(leftover)
+        self._encoded_size += len(output)
         return output
 
     def _encode_char_column(

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -32,8 +32,12 @@ async def startup(ctx: dict[Any, Any]) -> None:
     )
     logger = get_logger("qservkafka").bind(worker_instance=uuid.uuid4().hex)
 
-    # Allow the test suite to override the Kafka broker to use a mock.
-    context = await ProcessContext.create(ctx.get("kafka_broker"))
+    # Allow the test suite to override the process context to, for example,
+    # provide mock metrics event publishers that are accessible to the test.
+    if "context" in ctx:
+        context = ctx["context"]
+    else:
+        context = await ProcessContext.create()
     session = await create_async_session(context.engine)
     factory = Factory(context, session, logger)
 

--- a/tests/support/arq.py
+++ b/tests/support/arq.py
@@ -5,17 +5,15 @@ from __future__ import annotations
 import inspect
 
 from arq import Worker
-from faststream.kafka import KafkaBroker
 
 from qservkafka.config import config
+from qservkafka.factory import ProcessContext
 from qservkafka.workers.main import WorkerSettings
 
 __all__ = ["run_arq_jobs"]
 
 
-async def run_arq_jobs(
-    kafka_broker: KafkaBroker | None = None,
-) -> int:
+async def run_arq_jobs(context: ProcessContext | None = None) -> int:
     """Run any queued arq jobs.
 
     Returns
@@ -24,8 +22,8 @@ async def run_arq_jobs(
         Number of jobs run.
     """
     ctx = {}
-    if kafka_broker:
-        ctx["kafka_broker"] = kafka_broker
+    if context:
+        ctx["context"] = context
     WorkerSettings.redis_settings = config.arq_redis_settings
     worker_args = set(inspect.signature(Worker).parameters.keys())
     worker = Worker(


### PR DESCRIPTION
Found and fixed a bug in the `encoded_size` field of success metrics events. Previously it was counting encoded size before base64 encoding, rather than afterwards.

Reworked how to pass in test objects for arq worker functions to make it easier to test metrics events omitted by the result worker.