### PR TITLE
DM-51603: Add test for metrics events on query failure

### DIFF
--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -135,10 +135,8 @@ class QueryService:
             return self._build_invalid_request_status(job, msg)
         for column in job.result_format.column_types:
             if not column.is_string() and column.arraysize is not None:
-                return self._build_invalid_request_status(
-                    job,
-                    "arraysize only supported for char and unicodeChar fields",
-                )
+                m = "arraysize only supported for char and unicodeChar fields"
+                return self._build_invalid_request_status(job, m)
 
         # Increment the user's running queries and make sure they have space
         # to start a new query.


### PR DESCRIPTION
Add a test for posting a metrics event when a query is started but then fails inside Qserv. Currently, the bridge does not post metrics events for queries that fail before they are started, since they may be syntax errors or other user issues.