### PR TITLE
DM-51603: Add memory leak test with Kafka

### DIFF
--- a/tests/kafka/leak_test.py
+++ b/tests/kafka/leak_test.py
@@ -1,0 +1,145 @@
+"""Test for memory leaks in query processing.
+
+Each test repeats the leak tracing setup, rather than using a fixture, to
+ensure that the setup code is not included in the traced memory.
+"""
+
+from __future__ import annotations
+
+import gc
+import sys
+import tracemalloc
+from datetime import UTC, datetime
+
+import pytest
+import respx
+from aiokafka import AIOKafkaConsumer
+from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
+from faststream.kafka import KafkaBroker
+from safir.logging import LogLevel
+from safir.metrics import metrics_configuration_factory
+
+from qservkafka.config import config
+from qservkafka.dependencies.context import context_dependency
+from qservkafka.factory import Factory
+from qservkafka.models.qserv import AsyncQueryPhase, AsyncQueryStatus
+
+from ..support.arq import run_arq_jobs
+from ..support.kafka import start_query, wait_for_dispatch, wait_for_status
+from ..support.qserv import MockQserv
+
+
+@pytest.fixture(autouse=True)
+def disable_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the metrics events mock.
+
+    Disable metrics events logging entirely, rather than using the mock.
+    Otherwise, we accomulate metrics events in memory, which causes false
+    positives for memory leaks.
+    """
+    monkeypatch.delenv("METRICS_MOCK")
+    monkeypatch.setattr(config, "metrics", metrics_configuration_factory())
+
+
+@pytest.fixture(autouse=True)
+def set_log_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reduce log noise.
+
+    The leak test runs a bunch of queries, so cut down on logging. Debug-level
+    logging also appears to allocate a lot of memory. Hopefully this is not a
+    real memory leak.
+    """
+    monkeypatch.setattr(config, "log_level", LogLevel.WARNING)
+
+
+async def run_job(
+    *,
+    factory: Factory,
+    kafka_broker: KafkaBroker,
+    kafka_status_consumer: AIOKafkaConsumer,
+    mock_qserv: MockQserv,
+    execution_id: int,
+) -> None:
+    """Run a single job end-to-end."""
+    job = await start_query(kafka_broker, "data")
+    status = await wait_for_status(
+        kafka_status_consumer, "data-started", execution_id=str(execution_id)
+    )
+    assert status.query_info
+    start_time = status.query_info.start_time
+    await mock_qserv.store_results(job)
+    await mock_qserv.update_status(
+        execution_id,
+        AsyncQueryStatus(
+            query_id=execution_id,
+            status=AsyncQueryPhase.COMPLETED,
+            total_chunks=10,
+            completed_chunks=10,
+            collected_bytes=250,
+            query_begin=start_time,
+            last_update=datetime.now(tz=UTC),
+        ),
+    )
+    await wait_for_dispatch(factory, execution_id)
+    assert await run_arq_jobs(factory._context) == 1
+    await wait_for_status(
+        kafka_status_consumer, "data-completed", execution_id=str(execution_id)
+    )
+
+
+@pytest.mark.asyncio
+async def test_leak(
+    *,
+    app: FastAPI,
+    kafka_broker: KafkaBroker,
+    kafka_status_consumer: AIOKafkaConsumer,
+    mock_qserv: MockQserv,
+    respx_mock: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test for memory leaks in a full end-to-end Kafka flow."""
+    async with LifespanManager(app):
+        factory = context_dependency.create_factory()
+
+        # Run a single job to force any memory allocations that only happen
+        # once, during the first job.
+        await run_job(
+            factory=factory,
+            kafka_broker=kafka_broker,
+            kafka_status_consumer=kafka_status_consumer,
+            mock_qserv=mock_qserv,
+            execution_id=1,
+        )
+
+        # Start tracing memory.
+        gc.collect()
+        tracemalloc.start()
+        start_usage = tracemalloc.get_traced_memory()[0]
+
+        # Run 100 jobs through the system end to end.
+        for i in range(2, 102):
+            await run_job(
+                factory=factory,
+                kafka_broker=kafka_broker,
+                kafka_status_consumer=kafka_status_consumer,
+                mock_qserv=mock_qserv,
+                execution_id=i,
+            )
+
+        # Delete as much known stored data as possible, force garbage
+        # collection, and then stop tracing memory and gather usage.
+        mock_qserv.reset()
+        respx_mock.reset()
+        gc.collect()
+        end_usage = tracemalloc.get_traced_memory()[0]
+
+        # In practice memory usage change is never zero, so fail only if more
+        # than 1100KB was leaked.
+        if end_usage - start_usage >= 1_100_000:
+            snapshot = tracemalloc.take_snapshot()
+            top_stats = snapshot.statistics("lineno")
+            for stat in top_stats[:10]:
+                sys.stdout.write(str(stat) + "\n")
+            assert end_usage - start_usage < 1_100_000
+        tracemalloc.stop()

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import ANY
 
 import pytest
@@ -19,136 +18,15 @@ from testcontainers.redis import RedisContainer
 
 from qservkafka.config import config
 from qservkafka.dependencies.context import context_dependency
-from qservkafka.factory import Factory
 from qservkafka.models.gafaelfawr import GafaelfawrQuota, GafaelfawrTapQuota
-from qservkafka.models.kafka import JobRun, JobStatus
 from qservkafka.models.qserv import AsyncQueryPhase, AsyncQueryStatus
 from qservkafka.models.state import RunningQuery
 
 from ..support.arq import run_arq_jobs
-from ..support.data import (
-    read_test_job_cancel,
-    read_test_job_run,
-    read_test_job_run_json,
-    read_test_job_status,
-    read_test_job_status_json,
-)
-from ..support.datetime import (
-    assert_approximately_now,
-    milliseconds_to_timestamp,
-)
+from ..support.data import read_test_job_cancel, read_test_job_run
 from ..support.gafaelfawr import MockGafaelfawr
+from ..support.kafka import start_query, wait_for_dispatch, wait_for_status
 from ..support.qserv import MockQserv
-
-
-async def start_query(kafka_broker: KafkaBroker, job: str) -> JobRun:
-    """Send the Kafka message to start a query.
-
-    Parameters
-    ----------
-    kafka_broker
-        Kafka broker to use to send the message.
-    job
-        Name of the Kafka message to send.
-
-    Returns
-    -------
-    JobRun
-        Parsed version of the Kafka message.
-    """
-    job_model = read_test_job_run(job)
-    job_json = read_test_job_run_json(job)
-    await kafka_broker.publish(job_json, config.job_run_topic)
-    return job_model
-
-
-async def wait_for_status(
-    kafka_status_consumer: AIOKafkaConsumer,
-    status: str,
-    *,
-    execution_id: str | None = None,
-) -> JobStatus:
-    """Wait for a Kafka status message and check it.
-
-    Parameters
-    ----------
-    kafka_status_consumer
-        Consumer for the Kafka status topic.
-    status
-        Name to the Kafka status message to expect.
-    execution_id
-        If set, expect this execution ID instead of the one in the loaded JSON
-        file.
-
-    Returns
-    -------
-    JobStatus
-        Parsed Kafka status message.
-    """
-    expected = read_test_job_status_json(status)
-    status_model = read_test_job_status(status)
-    if execution_id is not None:
-        expected["executionID"] = execution_id
-        status_model.execution_id = execution_id
-
-    # Get the status message from Kafka and do the equality check
-    raw_message = await kafka_status_consumer.getone()
-    message = json.loads(raw_message.value.decode())
-    assert message == expected
-
-    # Check the timestamps and update the model to match the received message.
-    timestamp = milliseconds_to_timestamp(message["timestamp"])
-    assert_approximately_now(timestamp)
-    status_model.timestamp = timestamp
-    if message.get("queryInfo"):
-        start_time_milli = message["queryInfo"]["startTime"]
-        start_time = milliseconds_to_timestamp(start_time_milli)
-        assert_approximately_now(start_time)
-        assert status_model.query_info
-        status_model.query_info.start_time = start_time
-        if message["queryInfo"].get("endTime"):
-            end_time_milli = message["queryInfo"]["endTime"]
-            end_time = milliseconds_to_timestamp(end_time_milli)
-            assert_approximately_now(end_time)
-            status_model.query_info.end_time = end_time
-    return status_model
-
-
-async def wait_for_dispatch(
-    factory: Factory,
-    query_id: int,
-    *,
-    timeout: timedelta = timedelta(seconds=1),
-) -> None:
-    """Wait for a job to be queued for the result worker.
-
-    Parameters
-    ----------
-    factory
-        Component factory to use.
-    query_id
-        Qserv query ID.
-    timeout
-        How long to wait for the dispatch before giving up.
-
-    Raises
-    ------
-    TimeoutError
-        Raised if it takes more than the timeout interval for the job to be
-        dispatched to the backend worker.
-    """
-    state_store = factory.create_query_state_store()
-
-    # Use polling of Redis, since subscribing to key updates in Redis is
-    # complicated enough that I don't feel like writing all that code.
-    poll_delay = config.qserv_poll_interval.total_seconds() / 2
-    async with asyncio.timeout(timeout.total_seconds()):
-        while True:
-            query = await state_store.get_query(query_id)
-            assert query
-            if query.result_queued:
-                return
-            await asyncio.sleep(poll_delay)
 
 
 @pytest.mark.asyncio

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -79,7 +79,7 @@ async def test_success(
 
     # In practice memory usage change is never zero, so fail only if more than
     # 300KB was leaked.
-    if end_usage - start_usage >= 10_000:
+    if end_usage - start_usage >= 300_000:
         snapshot = tracemalloc.take_snapshot()
         top_stats = snapshot.statistics("lineno")
         for stat in top_stats[:10]:

--- a/tests/support/kafka.py
+++ b/tests/support/kafka.py
@@ -1,0 +1,141 @@
+"""Helper functions for running queries end-to-end with Kafka."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import timedelta
+
+from aiokafka import AIOKafkaConsumer
+from faststream.kafka import KafkaBroker
+
+from qservkafka.config import config
+from qservkafka.factory import Factory
+from qservkafka.models.kafka import JobRun, JobStatus
+
+from ..support.data import (
+    read_test_job_run,
+    read_test_job_run_json,
+    read_test_job_status,
+    read_test_job_status_json,
+)
+from ..support.datetime import (
+    assert_approximately_now,
+    milliseconds_to_timestamp,
+)
+
+__all__ = [
+    "start_query",
+    "wait_for_dispatch",
+    "wait_for_status",
+]
+
+
+async def start_query(kafka_broker: KafkaBroker, job: str) -> JobRun:
+    """Send the Kafka message to start a query.
+
+    Parameters
+    ----------
+    kafka_broker
+        Kafka broker to use to send the message.
+    job
+        Name of the Kafka message to send.
+
+    Returns
+    -------
+    JobRun
+        Parsed version of the Kafka message.
+    """
+    job_model = read_test_job_run(job)
+    job_json = read_test_job_run_json(job)
+    await kafka_broker.publish(job_json, config.job_run_topic)
+    return job_model
+
+
+async def wait_for_status(
+    kafka_status_consumer: AIOKafkaConsumer,
+    status: str,
+    *,
+    execution_id: str | None = None,
+) -> JobStatus:
+    """Wait for a Kafka status message and check it.
+
+    Parameters
+    ----------
+    kafka_status_consumer
+        Consumer for the Kafka status topic.
+    status
+        Name to the Kafka status message to expect.
+    execution_id
+        If set, expect this execution ID instead of the one in the loaded JSON
+        file.
+
+    Returns
+    -------
+    JobStatus
+        Parsed Kafka status message.
+    """
+    expected = read_test_job_status_json(status)
+    status_model = read_test_job_status(status)
+    if execution_id is not None:
+        expected["executionID"] = execution_id
+        status_model.execution_id = execution_id
+
+    # Get the status message from Kafka and do the equality check
+    raw_message = await kafka_status_consumer.getone()
+    message = json.loads(raw_message.value.decode())
+    assert message == expected
+
+    # Check the timestamps and update the model to match the received message.
+    timestamp = milliseconds_to_timestamp(message["timestamp"])
+    assert_approximately_now(timestamp)
+    status_model.timestamp = timestamp
+    if message.get("queryInfo"):
+        start_time_milli = message["queryInfo"]["startTime"]
+        start_time = milliseconds_to_timestamp(start_time_milli)
+        assert_approximately_now(start_time)
+        assert status_model.query_info
+        status_model.query_info.start_time = start_time
+        if message["queryInfo"].get("endTime"):
+            end_time_milli = message["queryInfo"]["endTime"]
+            end_time = milliseconds_to_timestamp(end_time_milli)
+            assert_approximately_now(end_time)
+            status_model.query_info.end_time = end_time
+    return status_model
+
+
+async def wait_for_dispatch(
+    factory: Factory,
+    query_id: int,
+    *,
+    timeout: timedelta = timedelta(seconds=1),
+) -> None:
+    """Wait for a job to be queued for the result worker.
+
+    Parameters
+    ----------
+    factory
+        Component factory to use.
+    query_id
+        Qserv query ID.
+    timeout
+        How long to wait for the dispatch before giving up.
+
+    Raises
+    ------
+    TimeoutError
+        Raised if it takes more than the timeout interval for the job to be
+        dispatched to the backend worker.
+    """
+    state_store = factory.create_query_state_store()
+
+    # Use polling of Redis, since subscribing to key updates in Redis is
+    # complicated enough that I don't feel like writing all that code.
+    poll_delay = config.qserv_poll_interval.total_seconds() / 2
+    async with asyncio.timeout(timeout.total_seconds()):
+        while True:
+            query = await state_store.get_query(query_id)
+            assert query
+            if query.result_queued:
+                return
+            await asyncio.sleep(poll_delay)


### PR DESCRIPTION
Add a memory leak test using the full end-to-end application with a real Kafka server and arq's burst mode. The memory leak threshold for failing has not yet been tuned.