### PR TITLE
DM-51603: Rework background tasks to not use shield

### DIFF
--- a/changelog.d/20250730_141256_rra_DM_51603a.md
+++ b/changelog.d/20250730_141256_rra_DM_51603a.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Avoid the use of `aiojobs.Scheduler.shield` in background tasks since it appears to cause a memory leak.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,6 @@ from testcontainers.core.network import Network
 from testcontainers.mysql import MySqlContainer
 from testcontainers.redis import RedisContainer
 
-from qservkafka.background import BackgroundTaskManager
 from qservkafka.config import config
 from qservkafka.factory import Factory, ProcessContext
 from qservkafka.main import create_app
@@ -52,18 +51,6 @@ async def app(
     monkeypatch.setattr(config, "kafka", kafka_connection_settings)
     monkeypatch.setattr(config, "qserv_poll_interval", poll_interval)
     return create_app()
-
-
-@pytest_asyncio.fixture
-async def background(
-    factory: Factory, logger: BoundLogger
-) -> AsyncGenerator[BackgroundTaskManager]:
-    """Create and start the background task manager."""
-    monitor = await factory.create_query_monitor()
-    background = BackgroundTaskManager(monitor, logger)
-    await background.start()
-    yield background
-    await background.stop()
 
 
 @pytest_asyncio.fixture

--- a/tests/support/arq.py
+++ b/tests/support/arq.py
@@ -10,25 +10,29 @@ from qservkafka.config import config
 from qservkafka.factory import ProcessContext
 from qservkafka.workers.main import WorkerSettings
 
-__all__ = ["run_arq_jobs"]
+__all__ = ["create_arq_worker"]
 
 
-async def run_arq_jobs(context: ProcessContext | None = None) -> int:
-    """Run any queued arq jobs.
+def create_arq_worker(context: ProcessContext | None = None) -> Worker:
+    """Create an arq worker to run queued jobs.
+
+    Parameters
+    ----------
+    context
+        Process context to use, if given.
 
     Returns
     -------
-    int
-        Number of jobs run.
+    Worker
+        arq worker.
     """
     ctx = {}
     if context:
         ctx["context"] = context
     WorkerSettings.redis_settings = config.arq_redis_settings
     worker_args = set(inspect.signature(Worker).parameters.keys())
-    worker = Worker(
+    return Worker(
         burst=True,
         ctx=ctx,
         **{k: v for k, v in vars(WorkerSettings).items() if k in worker_args},
     )
-    return await worker.run_check()


### PR DESCRIPTION
`aiojobs.Scheduler.shield` appears to cause a significant memory leak for reasons that are not clear. Refactor background task management to, instead of cancelling the tasks during shutdown, use an `asyncio.Event` and wait on it with `asyncio.wait_for` to implement the pauses between executions. This avoids the need for `shield` and appears to significantly reduce the memory leak.

Refactor the way that arq workers are created in the test suite to reuse more setup. This was an effort to eliminate a test suite memory leak in the arq worker code, but was unsuccessful. This seems to be specific to how the test suite is run.

Lower the thresholds for memory leak tests to account for the new savings.