### PR TITLE
Changed table upload process to delete user database instead of tables

### DIFF
--- a/changelog.d/20250730_220717_steliosvoutsinas_DM_52016.md
+++ b/changelog.d/20250730_220717_steliosvoutsinas_DM_52016.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Changed table upload process to delete user database instead of tables

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -433,15 +433,19 @@ class ResultProcessor:
         await self._state.delete_query(query.query_id)
         await self._rate_store.end_query(query.job.owner)
 
-        # Delete any temporary tables.
+        # Delete any temporary databases.
+        databases_to_delete = set()
         for upload in query.job.upload_tables:
+            databases_to_delete.add(upload.database)
+
+        for database in databases_to_delete:
             try:
-                await self._qserv.delete_table(upload.database, upload.table)
+                await self._qserv.delete_database(database)
             except QservApiError as e:
                 logger.exception(
-                    "Unable to delete temporary table, orphaning it",
+                    "Unable to delete temporary database, orphaning it",
                     error=str(e),
-                    table_name=upload.table_name,
+                    database_name=database,
                 )
 
     async def _upload_results(self, query: RunningQuery) -> UploadStats:

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -434,10 +434,7 @@ class ResultProcessor:
         await self._rate_store.end_query(query.job.owner)
 
         # Delete any temporary databases.
-        databases_to_delete = set()
-        for upload in query.job.upload_tables:
-            databases_to_delete.add(upload.database)
-
+        databases_to_delete = {t.database for t in query.job.upload_tables}
         for database in databases_to_delete:
             try:
                 await self._qserv.delete_database(database)

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -261,6 +261,21 @@ class QservClient:
         """
         await self._delete(f"/ingest/table/{database}/{table}")
 
+    async def delete_database(self, database: str) -> None:
+        """Delete a user database.
+
+        Parameters
+        ----------
+        database
+            Name of the database.
+
+        Raises
+        ------
+        QservApiError
+            Raised if there was some error deleting the database.
+        """
+        await self._delete(f"/ingest/database/{database}")
+
     async def get_query_results_gen(
         self, query_id: int
     ) -> AsyncGenerator[Row[Any]]:

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -269,6 +269,21 @@ class QservClient:
         database
             Name of the database.
 
+        Notes
+        -----
+        We delete the entire user database for each job rather than deleting
+        individual tables because we've now moved to creating a new database
+        for each new job.
+        The reason for this change is that in the current implementation of
+        QServ a failed upload can lead to a state where the user can no
+        longer upload tables to that database.
+        Also if a user attempts two simultaneous uploads, this could also
+        trigger a similar problem leaving the database in a problematic state.
+        So with a short lived database for each upload, it is now simpler
+        to just delete the whole temporary database once the job is
+        completed.
+
+
         Raises
         ------
         QservApiError

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -323,6 +323,7 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
     )
     finish = datetime.now(tz=UTC)
     assert mock_qserv.get_uploaded_table() is None
+    assert mock_qserv.get_uploaded_database() is None
 
     # Check that the correct metrics events were sent.
     assert isinstance(factory.events.query_success, MockEventPublisher)
@@ -364,6 +365,7 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
     started_status.execution_id = "2"
     assert status == started_status
     assert mock_qserv.get_uploaded_table() == job.upload_tables[0].table_name
+    assert mock_qserv.get_uploaded_database() == job.upload_tables[0].database
 
     # Only the second query should be active.
     assert await state_store.get_active_queries() == {2}

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -358,6 +358,10 @@ class MockQserv:
         self._check_auth(request)
         self._check_version(request)
         assert database == self._uploaded_database
+        if self._uploaded_table is not None:
+            assert self._uploaded_table.startswith(f"{database}."), (
+                f"Uploaded table must start with '{database}.'"
+            )
         self._uploaded_database = None
         self._uploaded_table = None
         return Response(200, json={"success": 1}, request=request)

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -142,7 +142,8 @@ class MockQserv:
         self._queries: dict[int, AsyncQueryStatus]
         self._results_stored: bool
         self._upload_delay: timedelta | None
-        self._uploaded_table: str | None
+        self._uploaded_table: str | None = None
+        self._uploaded_database: str | None = None
         self.reset()
 
     @classmethod
@@ -182,6 +183,16 @@ class MockQserv:
         """
         return self._uploaded_table
 
+    def get_uploaded_database(self) -> str | None:
+        """Get the set of uploaded database names.
+
+        Returns
+        -------
+        str | None
+            The uploaded database name or None.
+        """
+        return self._uploaded_database
+
     def register_mocks(self, mocks: list[MagicMock]) -> None:
         """Register additional magic mocks to clear on `reset`.
 
@@ -217,6 +228,7 @@ class MockQserv:
         self._results_stored = False
         self._upload_delay = None
         self._uploaded_table = None
+        self._uploaded_database = None
         for mock in self._mocks:
             mock.reset_mock()
 
@@ -324,10 +336,10 @@ class MockQserv:
         self._results_stored = False
         return Response(200, json={"success": 1}, request=request)
 
-    async def delete_table(
-        self, request: Request, database: str, table: str
+    async def delete_database(
+        self, request: Request, database: str
     ) -> Response:
-        """Delete an uploaded table.
+        """Delete an uploaded database and all its tables.
 
         Parameters
         ----------
@@ -335,8 +347,6 @@ class MockQserv:
             Incoming request.
         database
             Name of the database.
-        table
-            Name of the table.
 
         Returns
         -------
@@ -347,7 +357,8 @@ class MockQserv:
             return Response(500, text="Something failed")
         self._check_auth(request)
         self._check_version(request)
-        assert f"{database}.{table}" == self._uploaded_table
+        assert database == self._uploaded_database
+        self._uploaded_database = None
         self._uploaded_table = None
         return Response(200, json={"success": 1}, request=request)
 
@@ -596,8 +607,8 @@ class MockQserv:
         expected_job = read_test_job_run("upload")
         upload_table = expected_job.upload_tables[0]
         expected = {
-            "database": upload_table.table_name.split(".", 1)[0],
-            "table": upload_table.table_name.split(".", 1)[1],
+            "database": upload_table.database,
+            "table": upload_table.table,
             "fields_terminated_by": ",",
             "charset_name": "utf8",
             "timeout": str(int(config.qserv_upload_timeout.total_seconds())),
@@ -610,8 +621,18 @@ class MockQserv:
             ),
             ("rows", ("table.csv", self._UPLOAD_CSV, "text/csv")),
         ]
+        database = upload_table.database
+
+        if self._uploaded_database is not None:
+            assert database == self._uploaded_database, (
+                f"Multiple databases in single job: expected "
+                f"'{self._uploaded_database}', "
+                f"got '{database}'"
+            )
+
         assert not self._uploaded_table, "Too many tables uploaded"
         self._uploaded_table = upload_table.table_name
+        self._uploaded_database = database
         return Response(200, json=BaseResponse(success=1).model_dump())
 
     def _check_auth(self, request: Request) -> None:
@@ -676,8 +697,8 @@ async def register_mock_qserv(
     respx_mock.post(url__regex=regex).mock(side_effect=mock.submit)
     regex = rf"{base}/ingest/csv"
     respx_mock.post(url__regex=regex).mock(side_effect=mock.upload_table)
-    regex = rf"{base}/ingest/table/(?P<database>[^/]+)/(?P<table>[^/?]+)"
-    respx_mock.delete(url__regex=regex).mock(side_effect=mock.delete_table)
+    regex = rf"{base}/ingest/database/(?P<database>[^/?]+)"
+    respx_mock.delete(url__regex=regex).mock(side_effect=mock.delete_database)
     regex = rf"{base}/query-async/(?P<query_id>[0-9]+)"
     respx_mock.delete(url__regex=regex).mock(side_effect=mock.cancel)
     regex = rf"{base}/query-async/result/(?P<query_id>[0-9]+)"


### PR DESCRIPTION
## Summary
We recently discussed a plan to modify the upload behaviour a bit to create a separate database for each user query to address certain issues with orphaned user databases in QServ not allowing new upload jobs to be run.

I have a PR on the TAP service to enable this by modifying the name of the database to include the job id here:
https://github.com/lsst-sqre/lsst-tap-service/pull/163

In this PR I've modified the `services/results.py` and `storage/qserv.py` modules to now delete the databases associated with an uploaded table rather than the table. 