### PR TITLE
DM-52122: Move Qserv status to data files for testing

### DIFF
--- a/tests/data/qserv/data-completed.json
+++ b/tests/data/qserv/data-completed.json
@@ -1,0 +1,10 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "COMPLETED",
+  "totalChunks": 10,
+  "completedChunks": 10,
+  "collectedBytes": 250,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}

--- a/tests/data/qserv/data-executing.json
+++ b/tests/data/qserv/data-executing.json
@@ -1,0 +1,9 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "EXECUTING",
+  "totalChunks": 10,
+  "completedChunks": 0,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}

--- a/tests/data/qserv/simple-completed.json
+++ b/tests/data/qserv/simple-completed.json
@@ -1,0 +1,10 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "COMPLETED",
+  "totalChunks": 10,
+  "completedChunks": 10,
+  "collectedBytes": 250,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}

--- a/tests/data/qserv/simple-failed.json
+++ b/tests/data/qserv/simple-failed.json
@@ -1,0 +1,10 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "FAILED",
+  "totalChunks": 10,
+  "completedChunks": 8,
+  "collectedBytes": 200,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}

--- a/tests/data/qserv/simple-large.json
+++ b/tests/data/qserv/simple-large.json
@@ -1,0 +1,10 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "FAILED_LR",
+  "totalChunks": 10,
+  "completedChunks": 8,
+  "collectedBytes": 860211304,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}

--- a/tests/data/qserv/simple-partial.json
+++ b/tests/data/qserv/simple-partial.json
@@ -1,0 +1,10 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "EXECUTING",
+  "totalChunks": 10,
+  "completedChunks": 5,
+  "collectedBytes": 150,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}

--- a/tests/data/qserv/upload-failed.json
+++ b/tests/data/qserv/upload-failed.json
@@ -1,0 +1,10 @@
+{
+  "queryId": 1,
+  "query": "SELECT TOP 10 * FROM table",
+  "status": "FAILED",
+  "totalChunks": 10,
+  "completedChunks": 8,
+  "collectedBytes": 200,
+  "queryBeginEpoch": 1754607182,
+  "lastUpdateEpoch": 1754607184
+}


### PR DESCRIPTION
In the test suite, move Qserv status objects to data files and add a new helper function to load those data files. This keeps all of the test data together so that it can be consistently updated by changing the data files. It also prepares for adding new data fields.