### PR TITLE
DM-52122: Do not initialize arq metrics in the frontend

### DIFF
--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar
 
 from safir.database import create_async_session
 from safir.logging import configure_logging
-from safir.metrics.arq import make_on_job_start
+from safir.metrics.arq import initialize_arq_metrics, make_on_job_start
 from structlog import get_logger
 
 from ..config import config
@@ -39,10 +39,19 @@ async def startup(ctx: dict[Any, Any]) -> None:
         context = ctx["context"]
     else:
         context = await ProcessContext.create()
+
     session = await create_async_session(context.engine)
     factory = Factory(context, session, logger)
 
-    ctx.update(context.arq_context_additions)
+    # Metrics initialization must be done exactly once. If not done at all,
+    # the on_job_start function fails; if done more than once, Safir's metrics
+    # manager complains about duplicate registered metrics. This is not an
+    # issue during normal arq operations, but the test suite runs the worker
+    # multiple times in burst mode, which calls on_startup each time.
+    if not ctx.get("metrics_initialized"):
+        await initialize_arq_metrics(context.event_manager, ctx)
+        ctx["metrics_initialized"] = True
+
     ctx["context"] = context
     ctx["session"] = session
     ctx["factory"] = factory


### PR DESCRIPTION
Move arq metrics initialization out of `ProcessContext` so that they're not unnecessarily initialized in the frontend and into the arq worker startup. This requires a somewhat annoying workaround to not initialize metrics more than once for tests that call the worker multiple times in burst mode.