### PR TITLE
DM-52122: Request API version 47 instead of 43

### DIFF
--- a/changelog.d/20250808_113750_rra_DM_52122.md
+++ b/changelog.d/20250808_113750_rra_DM_52122.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Request version 47 of the Qserv REST API instead of version 43. This only applies if the Qserv Kafka bridge is configured to send versions in REST API requests.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -45,7 +45,7 @@ from ..models.qserv import (
     TableUploadStats,
 )
 
-API_VERSION = 43
+API_VERSION = 47
 """Version of the REST API that this client requests."""
 
 __all__ = ["API_VERSION", "QservClient"]


### PR DESCRIPTION
Update to match the current Qserv REST API version, if the bridge is configured to send versions on requests.