### PR TITLE
DM-52122: Don't log qserv_size if it is zero

### DIFF
--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -95,5 +95,6 @@ class RunningQuery(Query):
         result = super().to_logging_context()
         result["total_chunks"] = self.status.total_chunks
         result["completed_chunks"] = self.status.completed_chunks
-        result["qserv_size"] = self.status.collected_bytes
+        if self.status.collected_bytes:
+            result["qserv_size"] = self.status.collected_bytes
         return result


### PR DESCRIPTION
When adding Qserv query status information to the logging context, omit `qserv_size` if Qserv hasn't reported collecting any bytes. This is the common case for executing queries since we don't retrieve the byte count from running queries.