### PR TITLE
DM-52122: Fix logging for running query status update

### DIFF
--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -116,6 +116,7 @@ class QueryMonitor:
             query.status.update_from(status)
             update = self._results.build_executing_status(query)
             await self._state.update_status(query.query_id, query.status)
+            logger = self._logger.bind(**query.to_logging_context())
             logger.debug("Sending status update for running query")
             return update
         else:


### PR DESCRIPTION
Rebind the logger before logging the status update for a running query since the metadata about the query included in the log messages will have changed.