### PR TITLE
DM-52277: Fix collation setting for user table upload

### DIFF
--- a/changelog.d/20250822_092659_rra_DM_52277.md
+++ b/changelog.d/20250822_092659_rra_DM_52277.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Set character set to `utf8mb4` and collation to `utf8mb4_unicode_520_ci` when creating user-uploaded tables in Qserv. This allows the full range of valid UTF-8 characters and forces a matching collation, instead of using the non-matching collation default in API version 49.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -435,7 +435,8 @@ class QservClient:
                 "database": upload.database,
                 "table": upload.table,
                 "fields_terminated_by": ",",
-                "charset_name": "utf8",
+                "charset_name": "utf8mb4",
+                "collation_name": "utf8mb4_unicode_520_ci",
                 "timeout": int(config.qserv_upload_timeout.total_seconds()),
             },
             files=(

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -615,7 +615,8 @@ class MockQserv:
             "database": upload_table.database,
             "table": upload_table.table,
             "fields_terminated_by": ",",
-            "charset_name": "utf8",
+            "charset_name": "utf8mb4",
+            "collation_name": "utf8mb4_unicode_520_ci",
             "timeout": str(int(config.qserv_upload_timeout.total_seconds())),
         }
         assert data == expected


### PR DESCRIPTION
Change the character set name for user table upload to full UTF-8 and set `collation_name` to a matching collation, since the new version of Qserv now supports setting the collation name and uses a non-matching default.