### PR TITLE
DM-52277: Request version 49 of the Qserv REST API

### DIFF
--- a/changelog.d/20250822_095548_rra_DM_52277.md
+++ b/changelog.d/20250822_095548_rra_DM_52277.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Request version 49 of the Qserv REST API instead of version 47. This only applies if the Qserv Kafka bridge is configured to send versions in REST API requests.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -45,7 +45,7 @@ from ..models.qserv import (
     TableUploadStats,
 )
 
-API_VERSION = 47
+API_VERSION = 49
 """Version of the REST API that this client requests."""
 
 __all__ = ["API_VERSION", "QservClient"]


### PR DESCRIPTION
This will continue to be disabled by default in Phalanx.