### PR TITLE
DM-52277: Update collation to utf8mb4_uca1400_ai_ci

### DIFF
--- a/changelog.d/20250822_124622_rra_DM_52277.md
+++ b/changelog.d/20250822_124622_rra_DM_52277.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Update collation for user tables to `utf8mb4_uca1400_ai_ci`, which uses a newer version of the Unicode standard.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -436,7 +436,7 @@ class QservClient:
                 "table": upload.table,
                 "fields_terminated_by": ",",
                 "charset_name": "utf8mb4",
-                "collation_name": "utf8mb4_unicode_520_ci",
+                "collation_name": "utf8mb4_uca1400_ai_ci",
                 "timeout": int(config.qserv_upload_timeout.total_seconds()),
             },
             files=(

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -616,7 +616,7 @@ class MockQserv:
             "table": upload_table.table,
             "fields_terminated_by": ",",
             "charset_name": "utf8mb4",
-            "collation_name": "utf8mb4_unicode_520_ci",
+            "collation_name": "utf8mb4_uca1400_ai_ci",
             "timeout": str(int(config.qserv_upload_timeout.total_seconds())),
         }
         assert data == expected


### PR DESCRIPTION
Update collation for user tables to `utf8mb4_uca1400_ai_ci`, which uses a newer version of the Unicode standard.