### PR TITLE
DM-52277: Support configuring the subscriber workers

### DIFF
--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -233,6 +233,12 @@ class Config(BaseSettings):
         ),
     )
 
+    subscriber_workers: int = Field(
+        10,
+        title="Kafka consumer workers",
+        description="Max workers for the Kafka job run topic",
+    )
+
     tap_service: str = Field(
         ...,
         title="TAP service name",

--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -57,6 +57,7 @@ def register_kafka_handlers(kafka_router: KafkaRouter) -> None:
         config.job_run_topic,
         auto_offset_reset="earliest",
         group_id=config.consumer_group_id,
+        max_workers=config.subscriber_workers,
     )(status_publisher(job_run))
     kafka_router.subscriber(
         config.job_cancel_topic,


### PR DESCRIPTION
FastStream defaults to a single worker per topic subscriber. Make this configurable for the job run topic and set the default to 10.