### PR TITLE
DM-52282: Stop using async_scoped_session

### DIFF
--- a/src/qservkafka/dependencies/context.py
+++ b/src/qservkafka/dependencies/context.py
@@ -1,11 +1,9 @@
 """Per-request context."""
 
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from faststream.kafka.fastapi import KafkaMessage
-from safir.database import create_async_session
-from sqlalchemy.ext.asyncio import async_scoped_session
 from structlog import get_logger
 from structlog.stdlib import BoundLogger
 
@@ -40,13 +38,10 @@ class ContextDependency:
 
     def __init__(self) -> None:
         self._process_context: ProcessContext | None = None
-        self._session: async_scoped_session | None = None
 
-    async def __call__(
-        self, message: KafkaMessage
-    ) -> AsyncGenerator[ConsumerContext]:
+    async def __call__(self, message: KafkaMessage) -> ConsumerContext:
         """Create a per-request context."""
-        if not self._process_context or not self._session:
+        if not self._process_context:
             raise RuntimeError("Context dependency not initialized")
 
         # The underlying Kafka messages can either be a single message or a
@@ -66,19 +61,13 @@ class ContextDependency:
         }
         logger = logger.bind(kafka=kafka_context)
 
-        try:
-            yield ConsumerContext(
-                logger=logger,
-                factory=Factory(self._process_context, self._session, logger),
-            )
-        finally:
-            # Cleanly shut down any session that was created from the shared
-            # session manager.
-            await self._session.remove()
+        # Return the per-message context.
+        return ConsumerContext(
+            logger=logger, factory=Factory(self._process_context, logger)
+        )
 
     async def aclose(self) -> None:
         """Clean up the per-process singletons."""
-        self._session = None
         if self._process_context:
             await self._process_context.aclose()
         self._process_context = None
@@ -95,18 +84,16 @@ class ContextDependency:
         Factory
             Newly-constructed factory.
         """
-        if not self._process_context or not self._session:
+        if not self._process_context:
             raise RuntimeError("Context dependency not initialized")
         logger = get_logger("qservkafka")
-        return Factory(self._process_context, self._session, logger)
+        return Factory(self._process_context, logger)
 
     async def initialize(self) -> None:
         """Initialize the process-wide shared context."""
         if self._process_context:
             await self.aclose()
         self._process_context = await ProcessContext.create()
-        engine = self._process_context.engine
-        self._session = await create_async_session(engine)
 
 
 context_dependency = ContextDependency()

--- a/src/qservkafka/workers/functions/results.py
+++ b/src/qservkafka/workers/functions/results.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy.ext.asyncio import async_scoped_session
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
@@ -22,7 +21,6 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: int) -> None:
         Qserv query ID of completed query.
     """
     factory: Factory = ctx["factory"]
-    session: async_scoped_session = ctx["session"]
     logger: BoundLogger = ctx["logger"]
     state = factory.create_query_state_store()
 
@@ -30,10 +28,7 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: int) -> None:
     if not query:
         return
     processor = factory.create_result_processor()
-    try:
-        status = await processor.build_query_status(query)
-    finally:
-        await session.remove()
+    status = await processor.build_query_status(query)
     if status.status == ExecutionPhase.EXECUTING:
         logger.warning(
             "Apparently completed job still executing",

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -6,7 +6,6 @@ import uuid
 from collections.abc import Callable
 from typing import Any, ClassVar
 
-from safir.database import create_async_session
 from safir.logging import configure_logging
 from safir.metrics.arq import initialize_arq_metrics, make_on_job_start
 from structlog import get_logger
@@ -39,9 +38,7 @@ async def startup(ctx: dict[Any, Any]) -> None:
         context = ctx["context"]
     else:
         context = await ProcessContext.create()
-
-    session = await create_async_session(context.engine)
-    factory = Factory(context, session, logger)
+    factory = Factory(context, logger)
 
     # Metrics initialization must be done exactly once. If not done at all,
     # the on_job_start function fails; if done more than once, Safir's metrics
@@ -53,7 +50,6 @@ async def startup(ctx: dict[Any, Any]) -> None:
         ctx["metrics_initialized"] = True
 
     ctx["context"] = context
-    ctx["session"] = session
     ctx["factory"] = factory
     ctx["logger"] = logger
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from faststream.kafka import KafkaBroker, TestKafkaBroker
 from httpx import ASGITransport, AsyncClient
 from pydantic import MySQLDsn, RedisDsn, SecretStr
 from safir.arq import ArqMode
-from safir.database import create_async_session, create_database_engine
+from safir.database import create_database_engine
 from safir.kafka import KafkaConnectionSettings, SecurityProtocol
 from safir.logging import configure_logging
 from safir.testing.containers import FullKafkaContainer
@@ -99,8 +99,7 @@ async def factory(
     async with TestKafkaBroker(kafka_broker) as mock_broker:
         context = await ProcessContext.create(mock_broker)
         async with aclosing(context):
-            session = await create_async_session(engine, logger)
-            yield Factory(context, session, logger)
+            yield Factory(context, logger)
     await kafka_broker.stop()
 
 

--- a/tests/kafka/leak_test.py
+++ b/tests/kafka/leak_test.py
@@ -129,6 +129,7 @@ async def test_leak(
 
         # Delete as much known stored data as possible, force garbage
         # collection, and then stop tracing memory and gather usage.
+        del arq_worker
         mock_qserv.reset()
         respx_mock.reset()
         gc.collect()
@@ -136,8 +137,8 @@ async def test_leak(
 
         # In practice memory usage change is never zero because Python and its
         # libraries aggressively cache a lot of objects. Fail only if more
-        # than 700KB was leaked.
-        limit = 700_000
+        # than 300KiB was leaked.
+        limit = 300_000
         if end_usage - start_usage >= limit:
             snapshot = tracemalloc.take_snapshot()
             top_stats = snapshot.statistics("lineno")


### PR DESCRIPTION
`async_scoped_session` via Safir creates a separate session for every asyncio task, which requires shutting down that session at the end of every task or the sessions are leaked. This appears to be the source of the memory leaks previously incorrectly blamed on aiojobs.

Since the Qserv Kafka bridge now uses short-lived worker tasks, stop managing sessions with `async_scoped_session` and instead pass an `async_sessionmaker` down into the storage layer and create a new context-scoped session for each database operation.