### PR TITLE
DM-52282: Track time to submit query to Qserv

### DIFF
--- a/changelog.d/20250826_140246_rra_DM_52282b.md
+++ b/changelog.d/20250826_140246_rra_DM_52282b.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Add `submit_elapsed` to successful query metrics, which tracks the elapsed time from the receipt of the query to successfully starting the query in Qserv and retrieving its initial status.

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -57,7 +57,7 @@ class QuerySuccessEvent(BaseQueryEvent):
 
     elapsed: timedelta = Field(
         ...,
-        title="Query time (seconds)",
+        title="Query time",
         description=(
             "Time elapsed from initial receipt of the Kafka request to upload"
             " of results and sending of the completion Kafka message"
@@ -66,15 +66,24 @@ class QuerySuccessEvent(BaseQueryEvent):
 
     qserv_elapsed: timedelta = Field(
         ...,
-        title="Qserv processing time (seconds)",
+        title="Qserv processing time",
         description="How long it took for Qserv to process the query",
     )
 
     result_elapsed: timedelta = Field(
         ...,
-        title="Result processing time (seconds)",
+        title="Result processing time",
         description=(
             "How long it took to retrieve, encode, and upload the results"
+        ),
+    )
+
+    submit_elapsed: timedelta = Field(
+        ...,
+        title="Job submission time",
+        description=(
+            "How long it took from receipt of the Kafka message to successful"
+            " creation of the query job in Qserv"
         ),
     )
 

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -41,6 +41,8 @@ class RunningQuery(Query):
 
     status: Annotated[AsyncQueryStatus, Field(title="Last known status")]
 
+    created: Annotated[datetime, Field(title="Creation time of Qserv query")]
+
     result_queued: Annotated[
         bool, Field(title="Whether queued for result procesing")
     ]
@@ -64,6 +66,7 @@ class RunningQuery(Query):
         return cls(
             query_id=query.query_id,
             start=query.start,
+            created=datetime.now(tz=UTC),
             job=query.job,
             status=status,
             result_queued=False,

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -249,12 +249,14 @@ class ResultProcessor:
             qserv_rate = query.status.collected_bytes / qserv_elapsed_sec
         else:
             qserv_rate = None
+        submit_elapsed = query.created - query.start
         event = QuerySuccessEvent(
             job_id=query.job.job_id,
             username=query.job.owner,
             elapsed=now - query.start,
             qserv_elapsed=qserv_elapsed,
             result_elapsed=stats.elapsed,
+            submit_elapsed=submit_elapsed,
             rows=stats.rows,
             qserv_size=query.status.collected_bytes,
             encoded_size=stats.data_bytes,
@@ -274,6 +276,7 @@ class ResultProcessor:
             elapsed=(now - query.start).total_seconds(),
             qserv_elapsed=qserv_elapsed_sec,
             result_elapsed=stats.elapsed.total_seconds(),
+            submit_elapsed=submit_elapsed.total_seconds(),
         )
 
         # Delete the results.

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -86,6 +86,7 @@ async def test_success(
         "elapsed": ANY,
         "qserv_elapsed": ANY,
         "result_elapsed": ANY,
+        "submit_elapsed": ANY,
         "rows": 2,
         "qserv_size": qserv_status.collected_bytes,
         "encoded_size": ANY,

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -104,6 +104,7 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
         "elapsed": ANY,
         "qserv_elapsed": ANY,
         "result_elapsed": ANY,
+        "submit_elapsed": ANY,
         "rows": 2,
         "qserv_size": 250,
         "encoded_size": len(read_test_data("results/data.binary2")),
@@ -123,7 +124,12 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
         "upload_tables": 0,
         "immediate": True,
     }
-    for field in ("elapsed", "qserv_elapsed", "result_elapsed"):
+    for field in (
+        "elapsed",
+        "qserv_elapsed",
+        "result_elapsed",
+        "submit_elapsed",
+    ):
         assert timedelta(seconds=0) <= getattr(success_event, field) <= elapsed
 
     # It should be possible to immediately run the same query again. This
@@ -335,6 +341,7 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
         "elapsed": ANY,
         "qserv_elapsed": ANY,
         "result_elapsed": ANY,
+        "submit_elapsed": ANY,
         "rows": 2,
         "qserv_size": 250,
         "encoded_size": len(read_test_data("results/data.binary2")),


### PR DESCRIPTION
Add to the successful query metrics the length of time it took from receipt of the query to creating the query in Qserv. This has some overlap with qserv_elapsed, since it includes the time required to get the initial status of the query.