### PR TITLE
DM-52282: Fix query creation timing in metrics events

### DIFF
--- a/changelog.d/20250826_140246_rra_DM_52282b.md
+++ b/changelog.d/20250826_140246_rra_DM_52282b.md
@@ -1,3 +1,3 @@
 ### Other changes
 
-- Add `submit_elapsed` to successful query metrics, which tracks the elapsed time from the receipt of the query to successfully starting the query in Qserv and retrieving its initial status.
+- Add `submit_elapsed` to successful query metrics, which tracks the elapsed time from the receipt of the query to successfully starting the query in Qserv.

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -24,6 +24,10 @@ class Query(BaseModel):
 
     start: Annotated[datetime, Field(title="Receipt time of query")]
 
+    created: Annotated[
+        datetime | None, Field(title="Creation time of Qserv query")
+    ] = None
+
     job: Annotated[JobRun, Field(title="Full job request")]
 
     def to_logging_context(self) -> dict[str, Any]:
@@ -40,8 +44,6 @@ class RunningQuery(Query):
     """Represents a running Qserv query with a known status."""
 
     status: Annotated[AsyncQueryStatus, Field(title="Last known status")]
-
-    created: Annotated[datetime, Field(title="Creation time of Qserv query")]
 
     result_queued: Annotated[
         bool, Field(title="Whether queued for result procesing")
@@ -66,7 +68,7 @@ class RunningQuery(Query):
         return cls(
             query_id=query.query_id,
             start=query.start,
-            created=datetime.now(tz=UTC),
+            created=query.created,
             job=query.job,
             status=status,
             result_queued=False,

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -302,8 +302,9 @@ class QueryService:
                 error=e.to_job_error(),
                 metadata=metadata,
             )
+        created = datetime.now(tz=UTC)
         logger.info("Started query", qserv_id=str(query_id))
 
         # Analyze the initial status and return it.
-        query = Query(query_id=query_id, job=job, start=start)
+        query = Query(query_id=query_id, job=job, start=start, created=created)
         return await self._results.build_query_status(query, initial=True)

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -240,6 +240,11 @@ class ResultProcessor:
         except (QservApiError, UploadWebError, TimeoutError) as e:
             return await self._build_exception_status(query, e)
 
+        # Can be removed and created made non-optional after the upgrade is
+        # fully deployed.
+        if not query.created:
+            query.created = query.start
+
         # Send a metrics event for the job completion and log it.
         now = datetime.now(tz=UTC)
         qserv_end = query.status.last_update or now


### PR DESCRIPTION
Stop mistakenly updating the `created` time each time the results processor polls Qserv for a new status and instead fix it immediately after creation of the query in Qserv (and before geting the query status for the first time).