### PR TITLE
DM-52282: Add more tuning parameters and adjust settings

### DIFF
--- a/changelog.d/20250827_141325_rra_DM_52282.md
+++ b/changelog.d/20250827_141325_rra_DM_52282.md
@@ -1,0 +1,9 @@
+### New features
+
+- Add a new configuration setting, `redis_max_connections`, to tune the size of the Redis connection pool.
+- Add a new configuration setting, `job_run_max_bytes`, to increase the size of a batch the bridge will read from Kafka at one time.
+
+### Bug fixes
+
+- Change the default for `max_worker_jobs` to 2, matching the Phalanx configuration. Because worker jobs are CPU-bound, there's rarely a reason to increase the number of jobs per worker higher than this.
+- Changed the defaults for the Qserv database connection pool and REST connection pool to align with the default for the message batch size.

--- a/src/qservkafka/constants.py
+++ b/src/qservkafka/constants.py
@@ -12,7 +12,6 @@ __all__ = [
     "RATE_LIMIT_RECONCILE_INTERVAL",
     "REDIS_BACKOFF_MAX",
     "REDIS_BACKOFF_START",
-    "REDIS_POOL_SIZE",
     "REDIS_POOL_TIMEOUT",
     "REDIS_RETRIES",
     "REDIS_TIMEOUT",
@@ -67,9 +66,6 @@ REDIS_BACKOFF_START = 0.2
 Exponential backoff will be used for subsequent retries, up to
 `REDIS_BACKOFF_MAX` total delay.
 """
-
-REDIS_POOL_SIZE = 5
-"""Size of the ephemeral Redis connection pool (without rate limiting.)"""
 
 REDIS_POOL_TIMEOUT = 30
 """Seconds to wait for a connection from the pool before giving up."""

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -23,7 +23,6 @@ from .config import config
 from .constants import (
     REDIS_BACKOFF_MAX,
     REDIS_BACKOFF_START,
-    REDIS_POOL_SIZE,
     REDIS_POOL_TIMEOUT,
     REDIS_RETRIES,
     REDIS_TIMEOUT,
@@ -115,7 +114,7 @@ class ProcessContext:
         redis_pool = BlockingConnectionPool.from_url(
             str(config.redis_url),
             password=redis_password,
-            max_connections=REDIS_POOL_SIZE,
+            max_connections=config.redis_max_connections,
             retry=Retry(backoff, REDIS_RETRIES),
             retry_on_timeout=True,
             socket_keepalive=True,

--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -52,6 +52,8 @@ def register_kafka_handlers(kafka_router: KafkaRouter) -> None:
         config.job_run_topic,
         auto_offset_reset="earliest",
         batch=True,
+        fetch_max_bytes=config.job_run_max_bytes,
+        max_partition_fetch_bytes=config.job_run_max_bytes,
         group_id=config.consumer_group_id,
         max_records=config.job_run_batch_size,
     )(job_run)


### PR DESCRIPTION
Add a setting for the maximum amount of data the Kafka consumer will consume at a time and set the default so that we can consume a full batch of wide queries. Change the default batch concurrency to 10 from 20 because this seems to work more smoothly with Qserv.

Add a setting for the Redis connection pool size and increase the default to account for the batch size plus some overhead for the monitor job.

Change the default for worker jobs per result worker to 2, matching the Phalanx configuration, and note that increasing it is probably pointless.

Lower the Qserv database connection pool size to something more realistic given the level of concurrency the bridge uses.