### PR TITLE
DM-52282: Reduce Qserv SQL pool size on workers

### DIFF
--- a/changelog.d/20250827_143342_rra_DM_52282.md
+++ b/changelog.d/20250827_143342_rra_DM_52282.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Limit the Qserv database connection pool size in remote workers to the number of simultaneous jobs that worker is willing to handle, rather than using the full pool size of the frontend (which is massive overkill for a typical worker).

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -37,7 +37,9 @@ async def startup(ctx: dict[Any, Any]) -> None:
     if "context" in ctx:
         context = ctx["context"]
     else:
-        context = await ProcessContext.create()
+        context = await ProcessContext.create(
+            qserv_database_pool_size=config.max_worker_jobs
+        )
     factory = Factory(context, logger)
 
     # Metrics initialization must be done exactly once. If not done at all,


### PR DESCRIPTION
The result workers were using the full SQL pool size of the frontend, which is silly. Override the pool size on result workers to match the number of simultaneous jobs the worker will accept.