### PR TITLE
DM-54788: Address slow serialization of results in bigquery-kafka

### DIFF
--- a/changelog.d/20260501_173741_steliosvoutsinas_DM_54788.md
+++ b/changelog.d/20260501_173741_steliosvoutsinas_DM_54788.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Switch BigQuery result streaming to the Storage Read API using Arrow-based retrieval. This improves result processing by making it faster at the expense of more resource utilization.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "fastapi>=0.112.2",
     "faststream[kafka]>=0.6",
     "google-cloud-bigquery>=3.25.0",
+    "google-cloud-bigquery-storage>=2.27",
     "httpx>=0.27",
     "humanize>=4.15.0",
     "memray>=1.17",

--- a/src/qservkafka/storage/bigquery.py
+++ b/src/qservkafka/storage/bigquery.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator, Callable, Coroutine, Sequence
+from collections.abc import (
+    AsyncGenerator,
+    Callable,
+    Coroutine,
+    Iterator,
+    Sequence,
+)
 from datetime import UTC, datetime
 from functools import wraps
 from typing import Any, Concatenate, Protocol, override
 
-from google.cloud import bigquery
+import pyarrow as pa
+from google.cloud import bigquery, bigquery_storage
 from google.cloud.bigquery import DatasetReference, QueryJob, QueryJobConfig
 from httpx import AsyncClient
 from safir.slack.webhook import SlackWebhookClient
@@ -29,8 +36,16 @@ from .backend import DatabaseBackend
 
 __all__ = ["BigQueryClient"]
 
-# Batch size for streaming result rows from BigQuery.
 _RESULT_BATCH_SIZE = 1000
+
+
+def _next_record_batch(
+    batch_iter: Iterator[pa.RecordBatch],
+) -> pa.RecordBatch | None:
+    try:
+        return next(batch_iter)
+    except StopIteration:
+        return None
 
 
 class _BigQueryClientProtocol(Protocol):
@@ -140,6 +155,7 @@ class BigQueryClient(DatabaseBackend):
         self._location = location
         self._http_client = http_client
         self._client = bigquery.Client(project=project, location=location)
+        self._storage_client = bigquery_storage.BigQueryReadClient()
 
     def _validate_query_job(self, job: Any, query_id: str) -> QueryJob:
         """Validate and return a `QueryJob`, raising errors for invalid states.
@@ -208,27 +224,15 @@ class BigQueryClient(DatabaseBackend):
     async def get_query_results_gen(
         self, query_id: str
     ) -> AsyncGenerator[Sequence[Any]]:
-        def _get_result() -> bigquery.table.RowIterator:
-            """Get validated job and return result iterator."""
+        def _setup_stream() -> Iterator[pa.RecordBatch]:
             job = self._client.get_job(query_id)
             validated_job = self._validate_query_job(job, query_id)
-            return validated_job.result()
-
-        def _fetch_batch(
-            result_iter: Any, batch_size: int = _RESULT_BATCH_SIZE
-        ) -> list[tuple[Any, ...]]:
-            """Fetch a batch of rows."""
-            batch = []
-            for _ in range(batch_size):
-                try:
-                    bq_row = next(result_iter)
-                    batch.append(tuple(bq_row.values()))
-                except StopIteration:
-                    break
-            return batch
+            return validated_job.result().to_arrow_iterable(
+                bqstorage_client=self._storage_client,
+            )
 
         try:
-            result = await asyncio.to_thread(_get_result)
+            batch_iter = await asyncio.to_thread(_setup_stream)
         except Exception as e:
             exc = BigQueryApiNetworkError.from_exception(
                 "get_results", self._project, e
@@ -237,19 +241,32 @@ class BigQueryClient(DatabaseBackend):
             self.logger.exception(msg, **exc.to_logging_context())
             raise exc from e
 
-        result_iter = iter(result)
         while True:
-            batch = await asyncio.to_thread(_fetch_batch, result_iter)
-            if not batch:
+            try:
+                batch = await asyncio.to_thread(_next_record_batch, batch_iter)
+            except Exception as e:
+                exc = BigQueryApiNetworkError.from_exception(
+                    "get_results", self._project, e
+                )
+                self.logger.exception(
+                    "Failed to stream BigQuery results",
+                    **exc.to_logging_context(),
+                )
+                raise exc from e
+            if batch is None:
                 break
-
-            for row_values in batch:
-                yield row_values
+            for offset in range(0, len(batch), _RESULT_BATCH_SIZE):
+                length = min(_RESULT_BATCH_SIZE, len(batch) - offset)
+                sliced = batch.slice(offset, length)
+                columns = [col.to_pylist() for col in sliced.columns]
+                if columns:
+                    for row in zip(*columns, strict=True):
+                        yield row
 
     @override
     @_retry
     async def get_query_status(self, query_id: str) -> BigQueryQueryStatus:
-        def _get_status() -> tuple[QueryJob, ByteProgress]:
+        def _get_status() -> tuple[QueryJob, ByteProgress, int | None]:
             """Retrieve status synchronously for async wrapping."""
             job = self._client.get_job(query_id)
 
@@ -262,10 +279,14 @@ class BigQueryClient(DatabaseBackend):
                 cached=job.cache_hit or False,
             )
 
-            return job, progress
+            final_rows = None
+            if job.done() and not job.error_result:
+                final_rows = job.result().total_rows
+
+            return job, progress, final_rows
 
         try:
-            job, progress = await asyncio.to_thread(_get_status)
+            job, progress, final_rows = await asyncio.to_thread(_get_status)
         except Exception as e:
             exc = BigQueryApiNetworkError.from_exception(
                 "get_status", self._project, e
@@ -295,9 +316,7 @@ class BigQueryClient(DatabaseBackend):
             query_begin=job.created,
             last_update=datetime.now(tz=UTC),
             collected_bytes=job.total_bytes_processed or 0,
-            final_rows=job.result().total_rows
-            if (job.done() and not job.error_result)
-            else None,
+            final_rows=final_rows,
         )
 
     @override

--- a/tests/storage/bigquery_test.py
+++ b/tests/storage/bigquery_test.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import google.cloud.bigquery as google_bigquery
+import google.cloud.bigquery_storage as google_bq_storage
+import pyarrow as pa
 import pytest
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud.bigquery import DatasetReference, QueryJob
@@ -42,20 +43,33 @@ def mock_bq_client() -> MagicMock:
 
 
 @pytest.fixture
+def mock_storage_client() -> MagicMock:
+    """Create a mock BigQuery Storage client."""
+    return MagicMock()
+
+
+@pytest.fixture
 def bigquery_client(
     mock_bq_client: MagicMock,
+    mock_storage_client: MagicMock,
     logger: BoundLogger,
     monkeypatch: pytest.MonkeyPatch,
 ) -> BigQueryClient:
     """Create a BigQueryClient with mocked dependencies."""
-    mock_client_class = MagicMock(return_value=mock_bq_client)
-    monkeypatch.setattr(google_bigquery, "Client", mock_client_class)
+    monkeypatch.setattr(
+        google_bigquery, "Client", MagicMock(return_value=mock_bq_client)
+    )
+    monkeypatch.setattr(
+        google_bq_storage,
+        "BigQueryReadClient",
+        MagicMock(return_value=mock_storage_client),
+    )
 
     http_client = Mock(spec=AsyncClient)
     events = Mock(spec=Events)
     slack_client = None
 
-    client = BigQueryClient(
+    return BigQueryClient(
         project="test-project",
         location="US",
         http_client=http_client,
@@ -63,10 +77,6 @@ def bigquery_client(
         slack_client=slack_client,
         logger=logger,
     )
-
-    client._client = mock_bq_client
-
-    return client
 
 
 @pytest.fixture
@@ -273,22 +283,24 @@ async def test_get_query_results_gen(
     bigquery_client: BigQueryClient,
     mock_bq_client: MagicMock,
 ) -> None:
-    class MockBQRow:
-        def __init__(self, fields: list[str], values_tuple: tuple) -> None:
-            self._fields = fields
-            self._values_tuple = values_tuple
-
-        def values(self) -> tuple:
-            return self._values_tuple
-
-        def items(self) -> list[tuple[str, Any]]:
-            return list(zip(self._fields, self._values_tuple, strict=True))
-
-    mock_row1 = MockBQRow(["id", "name", "value"], (1, "test1", 100.5))
-    mock_row2 = MockBQRow(["id", "name", "value"], (2, "test2", 200.5))
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("name", pa.string()),
+            pa.field("value", pa.float64()),
+        ]
+    )
+    batch = pa.record_batch(
+        [
+            pa.array([1, 2], type=pa.int64()),
+            pa.array(["test1", "test2"], type=pa.string()),
+            pa.array([100.5, 200.5], type=pa.float64()),
+        ],
+        schema=schema,
+    )
 
     mock_result = MagicMock()
-    mock_result.__iter__.return_value = iter([mock_row1, mock_row2])
+    mock_result.to_arrow_iterable.return_value = iter([batch])
 
     mock_job = MagicMock(spec=QueryJob)
     mock_job.done.return_value = True

--- a/uv.lock
+++ b/uv.lock
@@ -742,6 +742,22 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-bigquery-storage"
+version = "2.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/31/5c6fa9e7b8e266a765ec80d13a2b2852cb0a6d3733572e7dbdc0cb39003c/google_cloud_bigquery_storage-2.37.0.tar.gz", hash = "sha256:f88ee7f1e49db1e639da3d9a8b79835ca4bc47afbb514fb2adfc0ccb41a7fd97", size = 310578, upload-time = "2026-03-30T22:51:13.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/0e/2950d4d0160300f51c7397a080b1685d3e25b40badb2c96f03d58d0ee868/google_cloud_bigquery_storage-2.37.0-py3-none-any.whl", hash = "sha256:1e319c27ef60fc31030f6e0b52e5e891e1cdd50551effe8c6f673a4c3c56fcb6", size = 306678, upload-time = "2026-03-30T22:47:42.333Z" },
+]
+
+[[package]]
 name = "google-cloud-core"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1893,6 +1909,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "faststream", extra = ["kafka"] },
     { name = "google-cloud-bigquery" },
+    { name = "google-cloud-bigquery-storage" },
     { name = "httpx" },
     { name = "humanize" },
     { name = "memray" },
@@ -1947,6 +1964,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.112.2" },
     { name = "faststream", extras = ["kafka"], specifier = ">=0.6" },
     { name = "google-cloud-bigquery", specifier = ">=3.25.0" },
+    { name = "google-cloud-bigquery-storage", specifier = ">=2.27" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "memray", specifier = ">=1.17" },


### PR DESCRIPTION
## Description

This PR addresses JIRA issue: https://rubinobs.atlassian.net/browse/DM-54788 which describes query slowness for queries that return a relatively large result set. In the example described, the result is 1.7 GB, with the actual BigQuery job running within a second but the overall query taking 16 minutes due to the slow result processing.

This PR switches the BigQuery result processing from the REST/JSON API (which is how the RowIterator we get works when using the result() method on a job from the bigquery client library) to the Arrow-based BigQuery Storage Read API (`to_arrow_iterable`). Previously, we were fetching results row-by-row via the REST API, and deserializing each row from JSON, which was slower. The new approach streams column-based Arrow batches over gRPC, which is much more performant.

## Changes
- `get_query_results_gen` now uses `BigQueryReadClient` with `to_arrow_iterable`, streaming results as `pa.RecordBatch` objects
- final_rows calculation moved inside _get_status so the blocking job.result() call runs in a thread via asyncio.to_thread.

## Notes
- The Storage Read API is billed at $1.10/TiB with a 300 TiB/month free tier. Reads from temporary tables (where I think BigQuery materialises query results) are free and do not count against the free tier.
- This version is a bit more resource-hungry, so I've had to bump CPU to 2 and memory to 1 GiB for both the worker and the main bigquerykafka app.