### PR TITLE
DM-54840: Add capability to limit result size via a maximum result size limit passed in via configuration

### DIFF
--- a/changelog.d/20260501_190111_steliosvoutsinas_DM_54840.md
+++ b/changelog.d/20260501_190111_steliosvoutsinas_DM_54840.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Add configurable max result size limit.

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -143,6 +143,16 @@ class Config(BaseSettings):
         ),
     )
 
+    max_result_bytes: int | None = Field(
+        None,
+        title="Maximum result bytes",
+        description=(
+            "Maximum bytes that can be returned for a single query. "
+            "Results exceeding this will be truncated and returned with "
+            "an overflow marker. None means no limit."
+        ),
+    )
+
     bigquery_project: str = Field(
         "",
         title="BigQuery project ID",

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -219,9 +219,12 @@ class Binary2Encoder(VOTableEncoder):
         config: JobResultConfig,
         discovery_client: DiscoveryClient,
         logger: BoundLogger,
+        *,
+        max_bytes: int | None = None,
     ) -> None:
         super().__init__(config, discovery_client, logger)
         self._wrapper_size = 0
+        self._max_bytes = max_bytes
 
     @property
     @override
@@ -270,6 +273,17 @@ class Binary2Encoder(VOTableEncoder):
                 )
                 self._total_rows += 1
                 encoded.write(encoded_row)
+                if (
+                    self._max_bytes is not None
+                    and encoded.tell() >= self._max_bytes
+                ):
+                    self._logger.info(
+                        "Result truncated: max_result_bytes limit reached",
+                        max_bytes=self._max_bytes,
+                        rows_processed=self._total_rows,
+                    )
+                    overflow = True
+                    break
                 if self._total_rows % 100000 == 0:
                     self._logger.debug(f"Processed {self._total_rows} rows")
                 if encoded.tell() >= threshold:
@@ -905,7 +919,12 @@ class VOTableWriter:
                 )
                 mime_type = "application/vnd.apache.parquet"
             case JobResultType.VOTable:
-                encoder = Binary2Encoder(config, self._discovery, self._logger)
+                encoder = Binary2Encoder(
+                    config,
+                    self._discovery,
+                    self._logger,
+                    max_bytes=global_config.max_result_bytes,
+                )
                 mime_type = "application/x-votable+xml; serialization=binary2"
 
         generator = encoder.encode(results, maxrec=maxrec)

--- a/tests/storage/binary2_test.py
+++ b/tests/storage/binary2_test.py
@@ -197,3 +197,34 @@ async def test_type_encoder() -> None:
     ]
     for column, data, expected in tests:
         await assert_encoded_value(column, data, expected)
+
+
+@pytest.mark.asyncio
+async def test_max_bytes_truncation() -> None:
+    config = JobResultConfig(
+        format=JobResultFormat(
+            type=JobResultType.VOTable,
+            serialization=JobResultSerialization.BINARY2,
+        ),
+        column_types=[
+            JobResultColumnType.model_validate(
+                {"name": "a", "datatype": "int"}
+            )
+        ],
+        envelope=JobResultEnvelope(
+            header="<header>",
+            footer="<footer>",
+            footer_overflow="<overflow>",
+        ),
+    )
+    rows = [(1,), (2,), (3,)]
+    logger = get_logger(__name__)
+    encoder = Binary2Encoder(config, DiscoveryClient(), logger, max_bytes=1)
+    encoded = b""
+    async for blob in encoder.encode(data_generator(rows)):
+        encoded += blob
+
+    assert encoded.startswith(b"<header>")
+    assert encoded.endswith(b"<overflow>")
+    assert b"<footer>" not in encoded
+    assert encoder.total_rows < 3


### PR DESCRIPTION
We have a requirement for the PPDB TAP service to add a limit to the result size of a query, so this PR adds a `max_result_bytes` setting to the qserv-kafka configuration which can be used by any of the TAP services to set the result size limit in bytes. 
If the result exceeds that we stop processing rows and return with the overflow INFO element set.