### PR TITLE
DM-55229: Remove incorrect homepage from metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dynamic = ["version"]
 qserv-kafka = "qservkafka.cli:main"
 
 [project.urls]
-Homepage = "https://qserv-kafka.lsst.io"
 Source = "https://github.com/lsst-sqre/qserv-kafka"
 
 [build-system]

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -16,4 +16,3 @@ async def test_get_index(client: AsyncClient) -> None:
     assert isinstance(data["version"], str)
     assert isinstance(data["description"], str)
     assert isinstance(data["repository_url"], str)
-    assert isinstance(data["documentation_url"], str)


### PR DESCRIPTION
There is no qserv-kafka documentation page.