### PR TITLE
DM-55168: Add support for specifying user-partitioning

### DIFF
--- a/changelog.d/20260708_222321_steliosvoutsinas_DM_55168.md
+++ b/changelog.d/20260708_222321_steliosvoutsinas_DM_55168.md
@@ -1,0 +1,9 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Upload tables that are part of join queries with director tables are now ingested into Qserv as DIRECTOR or DEPENDENT partitioned tables, enabling more efficient spatial cross-match queries in QServ.
+
+### Bug fixes
+
+- Temporary upload databases are deleted when Qserv rejects a query at submission time

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -246,8 +246,9 @@ class JobResultConfig(BaseModel):
 class UploadTablePartitionType(StrEnum):
     """Partition strategy for a TAP_UPLOAD table in Qserv."""
 
-    DIRECTOR = "DIRECTOR"
-    DEPENDENT = "DEPENDENT"
+    REPLICATED = "replicated"
+    DIRECTOR = "director"
+    DEPENDENT = "dependent"
 
 
 def _partition_type_discriminator(v: Any) -> str:
@@ -255,7 +256,9 @@ def _partition_type_discriminator(v: Any) -> str:
         val = v.get("partitionType", v.get("partition_type"))
     else:
         val = getattr(v, "partition_type", None)
-    return str(val) if val is not None else "replicated"
+    if val is None:
+        return UploadTablePartitionType.REPLICATED
+    return str(val)
 
 
 class _UploadTableBase(BaseModel):
@@ -315,7 +318,7 @@ class ReplicatedTableUpload(_UploadTableBase):
     """Upload table fully replicated across all Qserv nodes."""
 
     partition_type: Annotated[
-        Literal["replicated"] | None,
+        Literal[UploadTablePartitionType.REPLICATED] | None,
         Field(validation_alias="partitionType"),
     ] = None
 
@@ -402,9 +405,9 @@ class DependentTableUpload(_UploadTableBase):
 
 
 JobTableUpload = Annotated[
-    Annotated[ReplicatedTableUpload, Tag("replicated")]
-    | Annotated[DirectorTableUpload, Tag("DIRECTOR")]
-    | Annotated[DependentTableUpload, Tag("DEPENDENT")],
+    Annotated[ReplicatedTableUpload, Tag(UploadTablePartitionType.REPLICATED)]
+    | Annotated[DirectorTableUpload, Tag(UploadTablePartitionType.DIRECTOR)]
+    | Annotated[DependentTableUpload, Tag(UploadTablePartitionType.DEPENDENT)],
     Discriminator(_partition_type_discriminator),
 ]
 

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -2,15 +2,17 @@
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
     BeforeValidator,
     ConfigDict,
+    Discriminator,
     Field,
     HttpUrl,
     PlainSerializer,
+    Tag,
 )
 from safir.pydantic import SecondsTimedelta
 from vo_models.uws.types import ExecutionPhase
@@ -32,6 +34,8 @@ type DatetimeMillis = Annotated[
 """Type for timestamps, which are represented in Kafka in milliseconds."""
 
 __all__ = [
+    "DependentTableUpload",
+    "DirectorTableUpload",
     "JobCancel",
     "JobError",
     "JobErrorCode",
@@ -46,6 +50,9 @@ __all__ = [
     "JobResultType",
     "JobRun",
     "JobStatus",
+    "JobTableUpload",
+    "ReplicatedTableUpload",
+    "UploadTablePartitionType",
 ]
 
 
@@ -236,8 +243,23 @@ class JobResultConfig(BaseModel):
     ] = None
 
 
-class JobTableUpload(BaseModel):
-    """Table to upload for a query."""
+class UploadTablePartitionType(StrEnum):
+    """Partition strategy for a TAP_UPLOAD table in Qserv."""
+
+    DIRECTOR = "DIRECTOR"
+    DEPENDENT = "DEPENDENT"
+
+
+def _partition_type_discriminator(v: Any) -> str:
+    if isinstance(v, dict):
+        val = v.get("partitionType") or v.get("partition_type")
+    else:
+        val = getattr(v, "partition_type", None)
+    return str(val) if val is not None else "replicated"
+
+
+class _UploadTableBase(BaseModel):
+    """Common fields for all upload table classes."""
 
     model_config = ConfigDict(validate_by_name=True)
 
@@ -283,6 +305,84 @@ class JobTableUpload(BaseModel):
     def table(self) -> str:
         """Name of the table."""
         return self.table_name.split(".", 1)[1]
+
+
+class ReplicatedTableUpload(_UploadTableBase):
+    """Upload table fully replicated across all Qserv nodes."""
+
+    partition_type: Annotated[
+        None,
+        Field(validation_alias="partitionType"),
+    ] = None
+
+
+class DirectorTableUpload(_UploadTableBase):
+    """Upload table spatially partitioned by RA/Dec (Qserv director table)."""
+
+    partition_type: Annotated[
+        Literal[UploadTablePartitionType.DIRECTOR],
+        Field(validation_alias="partitionType"),
+    ]
+
+    longitude_col_name: Annotated[
+        str,
+        Field(
+            title="Longitude column name", validation_alias="longitudeColName"
+        ),
+    ]
+
+    latitude_col_name: Annotated[
+        str,
+        Field(
+            title="Latitude column name", validation_alias="latitudeColName"
+        ),
+    ]
+
+
+class DependentTableUpload(_UploadTableBase):
+    """Upload table partitioned by FK reference to a director table."""
+
+    partition_type: Annotated[
+        Literal[UploadTablePartitionType.DEPENDENT],
+        Field(validation_alias="partitionType"),
+    ]
+
+    id_col_name: Annotated[
+        str,
+        Field(title="ID column name", validation_alias="idColName"),
+    ]
+
+    ref_director_database: Annotated[
+        str,
+        Field(
+            title="Reference director database",
+            validation_alias="refDirectorDatabase",
+        ),
+    ]
+
+    ref_director_table: Annotated[
+        str,
+        Field(
+            title="Reference director table",
+            validation_alias="refDirectorTable",
+        ),
+    ]
+
+    ref_director_id_col_name: Annotated[
+        str,
+        Field(
+            title="Reference director ID column name",
+            validation_alias="refDirectorIdColName",
+        ),
+    ]
+
+
+JobTableUpload = Annotated[
+    Annotated[ReplicatedTableUpload, Tag("replicated")]
+    | Annotated[DirectorTableUpload, Tag("DIRECTOR")]
+    | Annotated[DependentTableUpload, Tag("DEPENDENT")],
+    Discriminator(_partition_type_discriminator),
+]
 
 
 class JobMetadata(BaseModel):

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -1,5 +1,6 @@
 """Models for Kafka messages."""
 
+from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal, override
@@ -52,6 +53,7 @@ __all__ = [
     "JobStatus",
     "JobTableUpload",
     "ReplicatedTableUpload",
+    "UploadTableBase",
     "UploadTablePartitionType",
 ]
 
@@ -261,7 +263,7 @@ def _partition_type_discriminator(v: Any) -> str:
     return str(val)
 
 
-class _UploadTableBase(BaseModel):
+class UploadTableBase(BaseModel, ABC):
     """Common fields for all upload table classes."""
 
     model_config = ConfigDict(validate_by_name=True)
@@ -309,12 +311,12 @@ class _UploadTableBase(BaseModel):
         """Name of the table."""
         return self.table_name.split(".", 1)[1]
 
+    @abstractmethod
     def to_ingest_fields(self) -> dict[str, str | int]:
         """Qserv ingest API fields specific to this partition strategy."""
-        return {}
 
 
-class ReplicatedTableUpload(_UploadTableBase):
+class ReplicatedTableUpload(UploadTableBase):
     """Upload table fully replicated across all Qserv nodes."""
 
     partition_type: Annotated[
@@ -322,8 +324,12 @@ class ReplicatedTableUpload(_UploadTableBase):
         Field(validation_alias="partitionType"),
     ] = None
 
+    @override
+    def to_ingest_fields(self) -> dict[str, str | int]:
+        return {}
 
-class DirectorTableUpload(_UploadTableBase):
+
+class DirectorTableUpload(UploadTableBase):
     """Upload table spatially partitioned by RA/Dec (Qserv director table)."""
 
     partition_type: Annotated[
@@ -355,7 +361,7 @@ class DirectorTableUpload(_UploadTableBase):
         }
 
 
-class DependentTableUpload(_UploadTableBase):
+class DependentTableUpload(UploadTableBase):
     """Upload table partitioned by FK reference to a director table."""
 
     partition_type: Annotated[

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, override
 
 from pydantic import (
     BaseModel,
@@ -252,7 +252,7 @@ class UploadTablePartitionType(StrEnum):
 
 def _partition_type_discriminator(v: Any) -> str:
     if isinstance(v, dict):
-        val = v.get("partitionType") or v.get("partition_type")
+        val = v.get("partitionType", v.get("partition_type"))
     else:
         val = getattr(v, "partition_type", None)
     return str(val) if val is not None else "replicated"
@@ -306,12 +306,16 @@ class _UploadTableBase(BaseModel):
         """Name of the table."""
         return self.table_name.split(".", 1)[1]
 
+    def to_ingest_fields(self) -> dict[str, str | int]:
+        """Qserv ingest API fields specific to this partition strategy."""
+        return {}
+
 
 class ReplicatedTableUpload(_UploadTableBase):
     """Upload table fully replicated across all Qserv nodes."""
 
     partition_type: Annotated[
-        None,
+        Literal["replicated"] | None,
         Field(validation_alias="partitionType"),
     ] = None
 
@@ -337,6 +341,15 @@ class DirectorTableUpload(_UploadTableBase):
             title="Latitude column name", validation_alias="latitudeColName"
         ),
     ]
+
+    @override
+    def to_ingest_fields(self) -> dict[str, str | int]:
+        return {
+            "is_partitioned": 1,
+            "is_director": 1,
+            "longitude_col_name": self.longitude_col_name,
+            "latitude_col_name": self.latitude_col_name,
+        }
 
 
 class DependentTableUpload(_UploadTableBase):
@@ -375,6 +388,17 @@ class DependentTableUpload(_UploadTableBase):
             validation_alias="refDirectorIdColName",
         ),
     ]
+
+    @override
+    def to_ingest_fields(self) -> dict[str, str | int]:
+        return {
+            "is_partitioned": 1,
+            "is_director": 0,
+            "id_col_name": self.id_col_name,
+            "ref_director_database": self.ref_director_database,
+            "ref_director_table": self.ref_director_table,
+            "ref_director_id_col_name": self.ref_director_id_col_name,
+        }
 
 
 JobTableUpload = Annotated[

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -354,6 +354,7 @@ class QueryService:
             else:
                 await report_exception(e, self._slack_client)
                 logger.exception("Unable to start query", error=str(e))
+            await self._results.delete_upload_databases(job, logger)
             return JobStatus(
                 job_id=job.job_id,
                 execution_id=str(query_id) if query_id else None,

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -332,6 +332,7 @@ class QueryService:
                 msg = "Unable to upload table"
             await report_exception(e, self._slack_client)
             logger.exception(msg, error=str(e))
+            await self._results.delete_upload_databases(job, logger)
             return JobStatus(
                 job_id=job.job_id,
                 execution_id=None,

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -30,7 +30,13 @@ from ..exceptions import (
     QueryError,
     UploadWebError,
 )
-from ..models.kafka import JobError, JobErrorCode, JobResultInfo, JobStatus
+from ..models.kafka import (
+    JobError,
+    JobErrorCode,
+    JobResultInfo,
+    JobRun,
+    JobStatus,
+)
 from ..models.query import AsyncQueryPhase
 from ..models.state import Query, RunningQuery
 from ..models.votable import UploadStats
@@ -465,6 +471,30 @@ class ResultProcessor(ABC):
             metadata=metadata,
         )
 
+    async def delete_upload_databases(
+        self, job: JobRun, logger: BoundLogger
+    ) -> None:
+        """Delete any temporary databases created for uploaded tables.
+
+        Parameters
+        ----------
+        job
+            Job metadata.
+        logger
+            Logger to use.
+        """
+        databases_to_delete = {t.database for t in job.upload_tables}
+        for database in databases_to_delete:
+            try:
+                await self._backend.delete_database(database)
+            except BackendApiError as e:
+                await report_exception(e, slack_client=self._slack_client)
+                logger.exception(
+                    "Unable to delete temporary database, orphaning it",
+                    error=str(e),
+                    database_name=database,
+                )
+
     async def _delete_query_data(
         self, query: Query, logger: BoundLogger
     ) -> None:
@@ -482,19 +512,7 @@ class ResultProcessor(ABC):
         """
         await self._state.delete_query(query.query_id)
         await self._rate_store.end_query(query.job.owner)
-
-        # Delete any temporary databases.
-        databases_to_delete = {t.database for t in query.job.upload_tables}
-        for database in databases_to_delete:
-            try:
-                await self._backend.delete_database(database)
-            except BackendApiError as e:
-                await report_exception(e, slack_client=self._slack_client)
-                logger.exception(
-                    "Unable to delete temporary database, orphaning it",
-                    error=str(e),
-                    database_name=database,
-                )
+        await self.delete_upload_databases(query.job, logger)
 
     async def _upload_results(self, query: RunningQuery) -> UploadStats:
         """Retrieve and upload the results.

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -33,7 +33,12 @@ from ..exceptions import (
     QservApiWebError,
     TableUploadWebError,
 )
-from ..models.kafka import JobRun, JobTableUpload
+from ..models.kafka import (
+    DependentTableUpload,
+    DirectorTableUpload,
+    JobRun,
+    JobTableUpload,
+)
 from ..models.progress import ChunkProgress
 from ..models.qserv import (
     AsyncSubmitRequest,
@@ -334,16 +339,29 @@ class QservClient(DatabaseBackend):
         schema = await self._get_table(upload.schema_url)
         source = await self._get_table(upload.source_url)
         start = datetime.now(tz=UTC)
+        data: dict[str, str | int] = {
+            "database": upload.database,
+            "table": upload.table,
+            "fields_terminated_by": ",",
+            "charset_name": "utf8mb4",
+            "collation_name": "utf8mb4_uca1400_ai_ci",
+            "timeout": int(config.qserv_upload_timeout.total_seconds()),
+        }
+        if isinstance(upload, DirectorTableUpload):
+            data["is_partitioned"] = 1
+            data["is_director"] = 1
+            data["longitude_col_name"] = upload.longitude_col_name
+            data["latitude_col_name"] = upload.latitude_col_name
+        elif isinstance(upload, DependentTableUpload):
+            data["is_partitioned"] = 1
+            data["is_director"] = 0
+            data["id_col_name"] = upload.id_col_name
+            data["ref_director_database"] = upload.ref_director_database
+            data["ref_director_table"] = upload.ref_director_table
+            data["ref_director_id_col_name"] = upload.ref_director_id_col_name
         await self._post_multipart(
             "/ingest/csv",
-            data={
-                "database": upload.database,
-                "table": upload.table,
-                "fields_terminated_by": ",",
-                "charset_name": "utf8mb4",
-                "collation_name": "utf8mb4_uca1400_ai_ci",
-                "timeout": int(config.qserv_upload_timeout.total_seconds()),
-            },
+            data=data,
             files=(
                 ("schema", ("schema.json", schema, "application/json")),
                 ("rows", ("table.csv", source, "text/csv")),

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -33,12 +33,7 @@ from ..exceptions import (
     QservApiWebError,
     TableUploadWebError,
 )
-from ..models.kafka import (
-    DependentTableUpload,
-    DirectorTableUpload,
-    JobRun,
-    JobTableUpload,
-)
+from ..models.kafka import JobRun, JobTableUpload
 from ..models.progress import ChunkProgress
 from ..models.qserv import (
     AsyncSubmitRequest,
@@ -347,18 +342,7 @@ class QservClient(DatabaseBackend):
             "collation_name": "utf8mb4_uca1400_ai_ci",
             "timeout": int(config.qserv_upload_timeout.total_seconds()),
         }
-        if isinstance(upload, DirectorTableUpload):
-            data["is_partitioned"] = 1
-            data["is_director"] = 1
-            data["longitude_col_name"] = upload.longitude_col_name
-            data["latitude_col_name"] = upload.latitude_col_name
-        elif isinstance(upload, DependentTableUpload):
-            data["is_partitioned"] = 1
-            data["is_director"] = 0
-            data["id_col_name"] = upload.id_col_name
-            data["ref_director_database"] = upload.ref_director_database
-            data["ref_director_table"] = upload.ref_director_table
-            data["ref_director_id_col_name"] = upload.ref_director_id_col_name
+        data.update(upload.to_ingest_fields())
         await self._post_multipart(
             "/ingest/csv",
             data=data,

--- a/tests/data/jobs/upload-dependent.json
+++ b/tests/data/jobs/upload-dependent.json
@@ -1,0 +1,85 @@
+{
+  "query": "SELECT TOP 10 * FROM user_username.table",
+  "jobID": "uws123",
+  "ownerID": "username",
+  "resultDestination": "https://results.example.com/1",
+  "resultLocation": "https://gcs.example.com/upload",
+  "resultFormat": {
+    "format": {
+      "type": "VOTable",
+      "serialization": "BINARY2"
+    },
+    "envelope": {
+      "header": "<VOTable xmlns=\"http://www.ivoa.net/xml/VOTable/v1.3\" version=\"1.3\"><RESOURCE type=\"results\"><TABLE><FIELD ID=\"col_0\" arraysize=\"*\" datatype=\"char\" name=\"col1\"/>",
+      "footer": "</TABLE></RESOURCE></VOTable>",
+      "footerOverflow": "</TABLE><INFO name=\"QUERY_STATUS\" value=\"OVERFLOW\"/></RESOURCE></VOTABLE>"
+    },
+    "columnTypes": [
+      {
+        "name": "id",
+        "datatype": "int"
+      },
+      {
+        "name": "a",
+        "datatype": "boolean"
+      },
+      {
+        "name": "b",
+        "datatype": "char"
+      },
+      {
+        "name": "c",
+        "datatype": "char",
+        "arraysize": "10"
+      },
+      {
+        "name": "d",
+        "datatype": "char",
+        "arraysize": "*",
+        "requiresUrlRewrite": true
+      },
+      {
+        "name": "e",
+        "datatype": "double"
+      },
+      {
+        "name": "f",
+        "datatype": "float"
+      },
+      {
+        "name": "g",
+        "datatype": "int"
+      },
+      {
+        "name": "h",
+        "datatype": "long"
+      },
+      {
+        "name": "i",
+        "datatype": "char",
+        "arraysize": "4*"
+      },
+      {
+        "name": "j",
+        "datatype": "char",
+        "arraysize": "*"
+      },
+      {
+        "name": "k",
+        "datatype": "short"
+      }
+    ]
+  },
+  "uploadTables": [
+    {
+      "tableName": "user_username.table",
+      "sourceUrl": "https://gcs.example.com/table.csv",
+      "schemaUrl": "https://gcs.example.com/table.json",
+      "partitionType": "DEPENDENT",
+      "idColName": "objectId",
+      "refDirectorDatabase": "dp1",
+      "refDirectorTable": "Object",
+      "refDirectorIdColName": "objectId"
+    }
+  ]
+}

--- a/tests/data/jobs/upload-dependent.json
+++ b/tests/data/jobs/upload-dependent.json
@@ -75,7 +75,7 @@
       "tableName": "user_username.table",
       "sourceUrl": "https://gcs.example.com/table.csv",
       "schemaUrl": "https://gcs.example.com/table.json",
-      "partitionType": "DEPENDENT",
+      "partitionType": "dependent",
       "idColName": "objectId",
       "refDirectorDatabase": "dp1",
       "refDirectorTable": "Object",

--- a/tests/data/jobs/upload-director.json
+++ b/tests/data/jobs/upload-director.json
@@ -75,7 +75,7 @@
       "tableName": "user_username.table",
       "sourceUrl": "https://gcs.example.com/table.csv",
       "schemaUrl": "https://gcs.example.com/table.json",
-      "partitionType": "DIRECTOR",
+      "partitionType": "director",
       "longitudeColName": "ra",
       "latitudeColName": "dec"
     }

--- a/tests/data/jobs/upload-director.json
+++ b/tests/data/jobs/upload-director.json
@@ -1,0 +1,83 @@
+{
+  "query": "SELECT TOP 10 * FROM user_username.table",
+  "jobID": "uws123",
+  "ownerID": "username",
+  "resultDestination": "https://results.example.com/1",
+  "resultLocation": "https://gcs.example.com/upload",
+  "resultFormat": {
+    "format": {
+      "type": "VOTable",
+      "serialization": "BINARY2"
+    },
+    "envelope": {
+      "header": "<VOTable xmlns=\"http://www.ivoa.net/xml/VOTable/v1.3\" version=\"1.3\"><RESOURCE type=\"results\"><TABLE><FIELD ID=\"col_0\" arraysize=\"*\" datatype=\"char\" name=\"col1\"/>",
+      "footer": "</TABLE></RESOURCE></VOTable>",
+      "footerOverflow": "</TABLE><INFO name=\"QUERY_STATUS\" value=\"OVERFLOW\"/></RESOURCE></VOTABLE>"
+    },
+    "columnTypes": [
+      {
+        "name": "id",
+        "datatype": "int"
+      },
+      {
+        "name": "a",
+        "datatype": "boolean"
+      },
+      {
+        "name": "b",
+        "datatype": "char"
+      },
+      {
+        "name": "c",
+        "datatype": "char",
+        "arraysize": "10"
+      },
+      {
+        "name": "d",
+        "datatype": "char",
+        "arraysize": "*",
+        "requiresUrlRewrite": true
+      },
+      {
+        "name": "e",
+        "datatype": "double"
+      },
+      {
+        "name": "f",
+        "datatype": "float"
+      },
+      {
+        "name": "g",
+        "datatype": "int"
+      },
+      {
+        "name": "h",
+        "datatype": "long"
+      },
+      {
+        "name": "i",
+        "datatype": "char",
+        "arraysize": "4*"
+      },
+      {
+        "name": "j",
+        "datatype": "char",
+        "arraysize": "*"
+      },
+      {
+        "name": "k",
+        "datatype": "short"
+      }
+    ]
+  },
+  "uploadTables": [
+    {
+      "tableName": "user_username.table",
+      "sourceUrl": "https://gcs.example.com/table.csv",
+      "schemaUrl": "https://gcs.example.com/table.json",
+      "partitionType": "DIRECTOR",
+      "longitudeColName": "ra",
+      "latitudeColName": "dec"
+    }
+  ]
+}

--- a/tests/models/kafka_test.py
+++ b/tests/models/kafka_test.py
@@ -163,7 +163,7 @@ def test_upload_table_dependent() -> None:
                     "tableName": "user_me.mysources",
                     "sourceUrl": "https://gcs.example.com/data.csv",
                     "schemaUrl": "https://gcs.example.com/schema.json",
-                    "partitionType": "DEPENDENT",
+                    "partitionType": "dependent",
                     "idColName": "objectId",
                     "refDirectorDatabase": "dp1",
                     "refDirectorTable": "Object",

--- a/tests/models/kafka_test.py
+++ b/tests/models/kafka_test.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from vo_models.uws.types import ExecutionPhase
 
 from qservkafka.models.kafka import (
+    DependentTableUpload,
     JobError,
     JobErrorCode,
     JobMetadata,
@@ -139,3 +140,42 @@ def test_job_status() -> None:
             "database": "dp1",
         },
     }
+
+
+def test_upload_table_dependent() -> None:
+    job = JobRun.model_validate(
+        {
+            "query": "SELECT TOP 10 * FROM table",
+            "jobID": "uws123",
+            "ownerID": "me",
+            "resultDestination": "https://bucket/result.xml",
+            "resultFormat": {
+                "format": {"type": "VOTable", "serialization": "BINARY2"},
+                "envelope": {
+                    "header": "<VOTable>",
+                    "footer": "</VOTable>",
+                    "footerOverflow": "</VOTable>",
+                },
+                "columnTypes": [],
+            },
+            "uploadTables": [
+                {
+                    "tableName": "user_me.mysources",
+                    "sourceUrl": "https://gcs.example.com/data.csv",
+                    "schemaUrl": "https://gcs.example.com/schema.json",
+                    "partitionType": "DEPENDENT",
+                    "idColName": "objectId",
+                    "refDirectorDatabase": "dp1",
+                    "refDirectorTable": "Object",
+                    "refDirectorIdColName": "objectId",
+                }
+            ],
+        }
+    )
+    assert len(job.upload_tables) == 1
+    upload = job.upload_tables[0]
+    assert isinstance(upload, DependentTableUpload)
+    assert upload.id_col_name == "objectId"
+    assert upload.ref_director_database == "dp1"
+    assert upload.ref_director_table == "Object"
+    assert upload.ref_director_id_col_name == "objectId"

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -472,3 +472,41 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
 
     # Only the second query should be active.
     assert await state_store.get_active_queries() == {"2"}
+
+
+@pytest.mark.asyncio
+async def test_upload_director(
+    factory: Factory, mock_qserv: MockQserv
+) -> None:
+    """Test upload of a spatially-partitioned (director) table."""
+    query_service = factory.create_query_service()
+    job = read_test_job_run("upload-director")
+    completed_status = read_test_job_status("upload-completed")
+
+    await assert_query_successful(
+        query_service=query_service,
+        mock_qserv=mock_qserv,
+        job=job,
+        expected_status=completed_status,
+    )
+    assert mock_qserv.get_uploaded_table() is None
+    assert mock_qserv.get_uploaded_database() is None
+
+
+@pytest.mark.asyncio
+async def test_upload_dependent(
+    factory: Factory, mock_qserv: MockQserv
+) -> None:
+    """Test upload of a dependent (FK-partitioned) table."""
+    query_service = factory.create_query_service()
+    job = read_test_job_run("upload-dependent")
+    completed_status = read_test_job_status("upload-completed")
+
+    await assert_query_successful(
+        query_service=query_service,
+        mock_qserv=mock_qserv,
+        job=job,
+        expected_status=completed_status,
+    )
+    assert mock_qserv.get_uploaded_table() is None
+    assert mock_qserv.get_uploaded_database() is None

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -4,13 +4,15 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY
 
 import pytest
+from httpx import Response
 from pydantic import SecretStr
 from safir.metrics import MockEventPublisher
 from safir.testing.slack import MockSlackWebhook
+from vo_models.uws.types import ExecutionPhase
 
 from qservkafka.config import config
 from qservkafka.factory import Factory
-from qservkafka.models.kafka import JobRun, JobStatus
+from qservkafka.models.kafka import JobErrorCode, JobRun, JobStatus
 from qservkafka.services.query import QueryService
 
 from ..support.data import (
@@ -510,3 +512,26 @@ async def test_upload_dependent(
     )
     assert mock_qserv.get_uploaded_table() is None
     assert mock_qserv.get_uploaded_database() is None
+
+
+@pytest.mark.asyncio
+async def test_upload_submit_failure(
+    factory: Factory, mock_qserv: MockQserv
+) -> None:
+    """Test that a rejected submission cleans up any uploaded tables."""
+    query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
+    job = read_test_job_run("upload")
+
+    mock_qserv.set_submit_response(
+        Response(200, json={"success": 0, "error": "Some error"})
+    )
+    status = await query_service.start_query(job)
+
+    assert status.status == ExecutionPhase.ERROR
+    assert status.error
+    assert status.error.code == JobErrorCode.backend_error
+    assert mock_qserv.get_uploaded_table() is None
+    assert mock_qserv.get_uploaded_database() is None
+
+    assert await state_store.get_active_queries() == set()

--- a/tests/storage/bigquery_test.py
+++ b/tests/storage/bigquery_test.py
@@ -29,7 +29,7 @@ from qservkafka.models.kafka import (
     JobResultSerialization,
     JobResultType,
     JobRun,
-    JobTableUpload,
+    ReplicatedTableUpload,
 )
 from qservkafka.models.progress import ByteProgress
 from qservkafka.models.query import AsyncQueryPhase
@@ -345,7 +345,7 @@ async def test_delete_result(
 async def test_upload_table_not_implemented(
     bigquery_client: BigQueryClient,
 ) -> None:
-    upload = JobTableUpload(
+    upload = ReplicatedTableUpload(
         table_name="user_test.temp_table",
         source_url="https://example.com/data.csv",
         schema_url="https://example.com/schema.json",

--- a/tests/storage/query_test.py
+++ b/tests/storage/query_test.py
@@ -17,6 +17,7 @@ from qservkafka.models.kafka import (
     JobResultType,
     JobRun,
     JobTableUpload,
+    ReplicatedTableUpload,
 )
 from qservkafka.models.progress import ByteProgress, ChunkProgress
 from qservkafka.models.qserv import TableUploadStats
@@ -201,7 +202,7 @@ async def test_backend_delete_result() -> None:
 @pytest.mark.asyncio
 async def test_backend_upload_table() -> None:
     backend = MockDatabaseBackend()
-    upload = JobTableUpload(
+    upload = ReplicatedTableUpload(
         table_name="user_test.temp_table",
         source_url="https://example.com/data.csv",
         schema_url="https://example.com/schema.json",

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -23,7 +23,11 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from structlog.stdlib import BoundLogger
 
 from qservkafka.config import config
-from qservkafka.models.kafka import JobRun
+from qservkafka.models.kafka import (
+    DependentTableUpload,
+    DirectorTableUpload,
+    JobRun,
+)
 from qservkafka.models.qserv import (
     AsyncSubmitRequest,
     BaseResponse,
@@ -611,9 +615,9 @@ class MockQserv:
         body.close()
 
         # Check the request is correct.
-        expected_job = read_test_job_run("upload")
-        upload_table = expected_job.upload_tables[0]
-        expected = {
+        job = self._immediate_success or read_test_job_run("upload")
+        upload_table = job.upload_tables[0]
+        expected: dict[str, str] = {
             "database": upload_table.database,
             "table": upload_table.table,
             "fields_terminated_by": ",",
@@ -621,6 +625,22 @@ class MockQserv:
             "collation_name": "utf8mb4_uca1400_ai_ci",
             "timeout": str(int(config.qserv_upload_timeout.total_seconds())),
         }
+        if isinstance(upload_table, DirectorTableUpload):
+            expected["is_partitioned"] = "1"
+            expected["is_director"] = "1"
+            expected["longitude_col_name"] = upload_table.longitude_col_name
+            expected["latitude_col_name"] = upload_table.latitude_col_name
+        elif isinstance(upload_table, DependentTableUpload):
+            expected["is_partitioned"] = "1"
+            expected["is_director"] = "0"
+            expected["id_col_name"] = upload_table.id_col_name
+            expected["ref_director_database"] = (
+                upload_table.ref_director_database
+            )
+            expected["ref_director_table"] = upload_table.ref_director_table
+            expected["ref_director_id_col_name"] = (
+                upload_table.ref_director_id_col_name
+            )
         assert data == expected
         assert files == [
             (

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -23,11 +23,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from structlog.stdlib import BoundLogger
 
 from qservkafka.config import config
-from qservkafka.models.kafka import (
-    DependentTableUpload,
-    DirectorTableUpload,
-    JobRun,
-)
+from qservkafka.models.kafka import JobRun
 from qservkafka.models.qserv import (
     AsyncSubmitRequest,
     BaseResponse,
@@ -625,22 +621,8 @@ class MockQserv:
             "collation_name": "utf8mb4_uca1400_ai_ci",
             "timeout": str(int(config.qserv_upload_timeout.total_seconds())),
         }
-        if isinstance(upload_table, DirectorTableUpload):
-            expected["is_partitioned"] = "1"
-            expected["is_director"] = "1"
-            expected["longitude_col_name"] = upload_table.longitude_col_name
-            expected["latitude_col_name"] = upload_table.latitude_col_name
-        elif isinstance(upload_table, DependentTableUpload):
-            expected["is_partitioned"] = "1"
-            expected["is_director"] = "0"
-            expected["id_col_name"] = upload_table.id_col_name
-            expected["ref_director_database"] = (
-                upload_table.ref_director_database
-            )
-            expected["ref_director_table"] = upload_table.ref_director_table
-            expected["ref_director_id_col_name"] = (
-                upload_table.ref_director_id_col_name
-            )
+        for key, value in upload_table.to_ingest_fields().items():
+            expected[key] = str(value)
         assert data == expected
         assert files == [
             (


### PR DESCRIPTION
Adds support for ingesting TAP upload tables into Qserv as DIRECTOR (spatial partitioning) or DEPENDENT (fk-partitioned) tables instead of always fully-replicated which is what happens currently.
This will lead to more efficient cross match queries.

In the same PR I have a fix for deleting orphaned upload databases being left behind when a job fails to start.
