### PR TITLE
DM-55463: Properly handle errors during BINARY2 encoding

### DIFF
--- a/changelog.d/20260710_114226_rra_DM_55463.md
+++ b/changelog.d/20260710_114226_rra_DM_55463.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Catch errors during BINARY2 encoding of the VOTable, normally due to a schema mismatch with the data returned by the database, so that the job is terminated correctly with an error status. Include the column name and type in error reports.

--- a/src/qservkafka/exceptions.py
+++ b/src/qservkafka/exceptions.py
@@ -7,12 +7,13 @@ from safir.slack.blockkit import (
     SlackException,
     SlackMessage,
     SlackTextBlock,
+    SlackTextField,
     SlackWebException,
 )
 from safir.slack.sentry import SentryEventInfo
 from sqlalchemy.exc import SQLAlchemyError
 
-from .models.kafka import JobError, JobErrorCode
+from .models.kafka import JobError, JobErrorCode, JobResultColumnType
 from .models.qserv import BaseResponse
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "BigQueryApiFailedError",
     "BigQueryApiNetworkError",
     "BigQueryApiProtocolError",
+    "EncodingError",
     "QservApiError",
     "QservApiFailedError",
     "QservApiProtocolError",
@@ -54,6 +56,16 @@ class QueryError(SlackException):
         """
         return JobError(code=self.error, message=str(self))
 
+    def to_logging_context(self) -> dict[str, Any]:
+        """Convert exception details to logging context.
+
+        Returns
+        -------
+        dict
+            Dictionary of field names to values.
+        """
+        return {"error": str(self)}
+
 
 class BackendApiError(QueryError):
     """Base class for failures talking to any database backend API.
@@ -62,16 +74,6 @@ class BackendApiError(QueryError):
     Specific backends (Qserv, BigQuery) raise subclasses of this.
     """
 
-    def to_logging_context(self) -> dict[str, Any]:
-        """Convert exception details to logging context.
-
-        Returns
-        -------
-        dict
-            Dictionary of field names to values.
-        """
-        return {"error": str(self)}
-
 
 class BackendApiFailedError(BackendApiError):
     """A backend API request returned a failure status.
@@ -79,17 +81,6 @@ class BackendApiFailedError(BackendApiError):
     This is a generic base class, backend-specific subclasses should provide
     additional context.
     """
-
-    @override
-    def to_logging_context(self) -> dict[str, Any]:
-        """Convert exception details to logging context.
-
-        Returns
-        -------
-        dict
-            Dictionary of field names to values.
-        """
-        return {"error": str(self)}
 
 
 class BackendApiProtocolError(BackendApiError):
@@ -408,6 +399,66 @@ class QservApiSqlError(QservApiError, BackendApiSqlError):
         else:
             msg = type(exc).__name__
         return cls(f"SQL query error: {msg}")
+
+
+class EncodingError(QueryError):
+    """An error occurred while encoding the results into a VOTable."""
+
+    error = JobErrorCode.encoding_error
+
+    @classmethod
+    def from_exception(
+        cls, column: JobResultColumnType, exc: Exception
+    ) -> Self:
+        """Create the exception from column information and an exception.
+
+        Parameters
+        ----------
+        column
+            Specification for the column where the encoding failed.
+        exc
+            Underlying triggering exception.
+
+        Returns
+        -------
+        EncodingError
+            Newly-created exception.
+        """
+        if str(exc):
+            error = f"{type(exc).__name__}: {exc!s}"
+        else:
+            error = type(exc).__name__
+        return cls(column, f"Error encoding {column.name}: {error}")
+
+    def __init__(self, column: JobResultColumnType, message: str) -> None:
+        super().__init__(message)
+        self._column = column
+
+    @override
+    def to_logging_context(self) -> dict[str, Any]:
+        result = super().to_logging_context()
+        result["column"] = self._column.name
+        result["column_type"] = self._column.type_description
+        return result
+
+    @override
+    def to_slack(self) -> SlackMessage:
+        result = super().to_slack()
+        fields = [
+            SlackTextField(heading="Column", text=self._column.name),
+            SlackTextField(
+                heading="Column type", text=self._column.type_description
+            ),
+        ]
+        result.fields.extend(fields)
+        return result
+
+    @override
+    def to_sentry(self) -> SentryEventInfo:
+        info = super().to_sentry()
+        info.tags["column"] = self._column.name
+        info.tags["column_type"] = self._column.type_description
+        return info
 
 
 class QservApiWebError(QservApiError, BackendApiWebError):

--- a/src/qservkafka/exceptions.py
+++ b/src/qservkafka/exceptions.py
@@ -44,6 +44,7 @@ __all__ = [
 class QueryError(SlackException):
     """Base class for reportable query errors."""
 
+    description: ClassVar[str] = "Unable to retrieve results"
     error: ClassVar[JobErrorCode] = JobErrorCode.backend_error
 
     def to_job_error(self) -> JobError:
@@ -404,6 +405,7 @@ class QservApiSqlError(QservApiError, BackendApiSqlError):
 class EncodingError(QueryError):
     """An error occurred while encoding the results into a VOTable."""
 
+    description = "Unable to encode results"
     error = JobErrorCode.encoding_error
 
     @classmethod
@@ -476,4 +478,5 @@ class TableUploadWebError(SlackWebException, QueryError):
 class UploadWebError(SlackWebException, QueryError):
     """Upload of the query results failed."""
 
+    description = "Unable to upload results"
     error = JobErrorCode.upload_failed

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -176,6 +176,14 @@ class JobResultColumnType(BaseModel):
         ),
     ] = False
 
+    @property
+    def type_description(self) -> str:
+        """Data type as a human-readable string."""
+        result = self.datatype.name
+        if self.arraysize:
+            result += "(" + self.arraysize.to_string() + ")"
+        return result
+
     def is_string(self) -> bool:
         """Check whether the underlying data type is a string."""
         return self.datatype.is_string()
@@ -467,6 +475,7 @@ class JobErrorCode(StrEnum):
     backend_request_error = "backend_request_error"
     backend_results_too_large = "backend_results_too_large"
     backend_sql_error = "backend_sql_error"
+    encoding_error = "encoding_error"
     invalid_request = "invalid_request"
     quota_exceeded = "quota_exceeded"
     result_timeout = "result_timeout"

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -373,19 +373,16 @@ class ResultProcessor(ABC):
         elapsed_seconds = elapsed.total_seconds()
 
         # Analyze the exception.
+        await report_exception(exc, slack_client=self._slack_client)
         match exc:
             case QueryError():
-                if isinstance(exc, UploadWebError):
-                    msg = "Unable to upload results"
-                else:
-                    msg = "Unable to retrieve results"
-                await report_exception(exc, slack_client=self._slack_client)
                 logger.exception(
-                    msg, elapsed=elapsed_seconds, **exc.to_logging_context()
+                    exc.description,
+                    elapsed=elapsed_seconds,
+                    **exc.to_logging_context(),
                 )
                 error = exc.to_job_error()
             case TimeoutError():
-                await report_exception(exc, slack_client=self._slack_client)
                 logger.exception(
                     "Retrieving and uploading results timed out",
                     elapsed=elapsed_seconds,

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -380,7 +380,9 @@ class ResultProcessor(ABC):
                 else:
                     msg = "Unable to retrieve results"
                 await report_exception(exc, slack_client=self._slack_client)
-                logger.exception(msg, error=str(exc), elapsed=elapsed_seconds)
+                logger.exception(
+                    msg, elapsed=elapsed_seconds, **exc.to_logging_context()
+                )
                 error = exc.to_job_error()
             case TimeoutError():
                 await report_exception(exc, slack_client=self._slack_client)

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -27,6 +27,7 @@ from ..events import (
 from ..exceptions import (
     BackendApiError,
     BackendApiTransientError,
+    QueryError,
     UploadWebError,
 )
 from ..models.kafka import JobError, JobErrorCode, JobResultInfo, JobStatus
@@ -293,7 +294,7 @@ class ResultProcessor(ABC):
         # Retrieve and upload the results.
         try:
             stats = await self._upload_results_with_retry(query, logger)
-        except (BackendApiError, UploadWebError, TimeoutError) as e:
+        except (QueryError, TimeoutError) as e:
             return await self._build_exception_status(query, e)
 
         # Delete the results if configured to do so.
@@ -350,7 +351,7 @@ class ResultProcessor(ABC):
     async def _build_exception_status(
         self,
         query: RunningQuery,
-        exc: BackendApiError | UploadWebError | TimeoutError,
+        exc: QueryError | TimeoutError,
     ) -> JobStatus:
         """Construct the job status for an exception.
 
@@ -373,7 +374,7 @@ class ResultProcessor(ABC):
 
         # Analyze the exception.
         match exc:
-            case BackendApiError() | UploadWebError():
+            case QueryError():
                 if isinstance(exc, UploadWebError):
                     msg = "Unable to upload results"
                 else:

--- a/src/qservkafka/storage/votable.py
+++ b/src/qservkafka/storage/votable.py
@@ -20,7 +20,7 @@ from structlog.stdlib import BoundLogger
 
 from ..config import config as global_config
 from ..constants import UPLOAD_BUFFER_SIZE
-from ..exceptions import UploadWebError
+from ..exceptions import EncodingError, UploadWebError
 from ..models.kafka import JobResultColumnType, JobResultConfig, JobResultType
 from ..models.votable import EncodedSize, VOTablePrimitive
 
@@ -428,22 +428,30 @@ class Binary2Encoder(VOTableEncoder):
         -------
         bytes
             Encoded results in raw binary format, not base64-encoded.
+
+        Raises
+        ------
+        EncodingError
+            Raised if an error occurred encoding a row of the results.
         """
         nulls = BitArray(length=len(types))
         output = bytearray()
         for i, column in enumerate(types):
-            datatype = column.datatype
-            value = row[i]
-            if value is None:
-                nulls.set(True, i)
-            if datatype == VOTablePrimitive.char:
-                output += await self._encode_char_column(column, value)
-            elif datatype == VOTablePrimitive.unicode_char:
-                output += await self._encode_unicode_char_column(
-                    column=column, value_raw=value
-                )
-            else:
-                output += datatype.pack(value)
+            try:
+                datatype = column.datatype
+                value = row[i]
+                if value is None:
+                    nulls.set(True, i)
+                if datatype == VOTablePrimitive.char:
+                    output += await self._encode_char_column(column, value)
+                elif datatype == VOTablePrimitive.unicode_char:
+                    output += await self._encode_unicode_char_column(
+                        column=column, value_raw=value
+                    )
+                else:
+                    output += datatype.pack(value)
+            except Exception as e:
+                raise EncodingError.from_exception(column, e) from e
 
         return nulls.tobytes() + output
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from safir.database import create_database_engine
 from safir.kafka import KafkaConnectionSettings, SecurityProtocol
 from safir.logging import configure_logging
 from safir.testing.containers import FullKafkaContainer
+from safir.testing.data import Data
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from sqlalchemy.ext.asyncio import AsyncEngine
 from structlog.stdlib import BoundLogger, get_logger
@@ -32,6 +33,15 @@ from qservkafka.factory import Factory, ProcessContext
 from qservkafka.main import create_app
 
 from .support.qserv import MockQserv, register_mock_qserv
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-test-data",
+        action="store_true",
+        default=False,
+        help="Overwrite expected test output with current results",
+    )
 
 
 @pytest_asyncio.fixture
@@ -61,6 +71,12 @@ async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
         base_url="https://example.com/", transport=ASGITransport(app=app)
     ) as client:
         yield client
+
+
+@pytest.fixture
+def data(request: pytest.FixtureRequest) -> Data:
+    update = request.config.getoption("--update-test-data")
+    return Data(Path(__file__).parent / "data", update_test_data=update)
 
 
 @pytest_asyncio.fixture
@@ -239,7 +255,7 @@ async def mock_qserv(
 @pytest.fixture
 def mock_slack(
     monkeypatch: pytest.MonkeyPatch, respx_mock: respx.Router
-) -> MockSlackWebhook | None:
+) -> MockSlackWebhook:
     """Mock a Slack webhook."""
     webhook = SecretStr("https://slack.example.com/webhook")
     monkeypatch.setattr(config.slack, "enabled", True)

--- a/tests/data/jobs/data-wrong-schema.json
+++ b/tests/data/jobs/data-wrong-schema.json
@@ -1,0 +1,74 @@
+{
+  "query": "SELECT TOP 10 * FROM table",
+  "database": "dp1",
+  "jobID": "uws123",
+  "ownerID": "username",
+  "resultDestination": "https://results.example.com/1",
+  "resultLocation": "https://gcs.example.com/upload",
+  "resultFormat": {
+    "format": {
+      "type": "VOTable",
+      "serialization": "BINARY2"
+    },
+    "envelope": {
+      "header": "<VOTable xmlns=\"http://www.ivoa.net/xml/VOTable/v1.3\" version=\"1.3\"><RESOURCE type=\"results\"><TABLE><FIELD ID=\"col_0\" arraysize=\"*\" datatype=\"char\" name=\"col1\"/>\n",
+      "footer": "</TABLE></RESOURCE></VOTable>\n",
+      "footerOverflow": "</TABLE><INFO name=\"QUERY_STATUS\" value=\"OVERFLOW\"/></RESOURCE></VOTABLE>"
+    },
+    "columnTypes": [
+      {
+        "name": "id",
+        "datatype": "int"
+      },
+      {
+        "name": "a",
+        "datatype": "boolean"
+      },
+      {
+        "name": "b",
+        "datatype": "char"
+      },
+      {
+        "name": "c",
+        "datatype": "char",
+        "arraysize": "10"
+      },
+      {
+        "name": "d",
+        "datatype": "char",
+        "arraysize": "*",
+        "requiresUrlRewrite": true
+      },
+      {
+        "name": "e",
+        "datatype": "double"
+      },
+      {
+        "name": "f",
+        "datatype": "float"
+      },
+      {
+        "name": "g",
+        "datatype": "int"
+      },
+      {
+        "name": "h",
+        "datatype": "int"
+      },
+      {
+        "name": "i",
+        "datatype": "char",
+        "arraysize": "4*"
+      },
+      {
+        "name": "j",
+        "datatype": "char",
+        "arraysize": "*"
+      },
+      {
+        "name": "k",
+        "datatype": "short"
+      }
+    ]
+  }
+}

--- a/tests/data/slack/wrong-schema.json
+++ b/tests/data/slack/wrong-schema.json
@@ -1,0 +1,42 @@
+[
+  {
+    "blocks": [
+      {
+        "text": {
+          "text": "Error in qserv-kafka: Error encoding h: error: 'l' format requires -2147483648 &lt;= number &lt;= 2147483647",
+          "type": "mrkdwn",
+          "verbatim": true
+        },
+        "type": "section"
+      },
+      {
+        "fields": [
+          {
+            "text": "*Exception type*\nEncodingError",
+            "type": "mrkdwn",
+            "verbatim": true
+          },
+          {
+            "text": "<ANY>",
+            "type": "mrkdwn",
+            "verbatim": true
+          },
+          {
+            "text": "*Column*\nh",
+            "type": "mrkdwn",
+            "verbatim": true
+          },
+          {
+            "text": "*Column type*\nint",
+            "type": "mrkdwn",
+            "verbatim": true
+          }
+        ],
+        "type": "section"
+      },
+      {
+        "type": "divider"
+      }
+    ]
+  }
+]

--- a/tests/data/status/data-wrong-schema.json
+++ b/tests/data/status/data-wrong-schema.json
@@ -1,0 +1,14 @@
+{
+  "job_id": "uws123",
+  "execution_id": "1",
+  "timestamp": 1743540791,
+  "status": "ERROR",
+  "error": {
+    "code": "encoding_error",
+    "message": "Error encoding h: error: 'l' format requires -2147483648 <= number <= 2147483647"
+  },
+  "metadata": {
+    "query": "SELECT TOP 10 * FROM table",
+    "database": "dp1"
+  }
+}

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -17,6 +17,8 @@ from rubin.gafaelfawr import (
     MockGafaelfawr,
 )
 from safir.metrics import MockEventPublisher
+from safir.testing.data import Data
+from safir.testing.slack import MockSlackWebhook
 from testcontainers.redis import RedisContainer
 
 from qservkafka.config import config
@@ -415,3 +417,46 @@ async def test_quota(
             kafka_status_consumer, "data-started", execution_id="3"
         )
         assert redis_client.get(f"rate:{job.owner}") == b"2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(40)
+async def test_wrong_schema(
+    *,
+    data: Data,
+    app: FastAPI,
+    kafka_broker: KafkaBroker,
+    kafka_status_consumer: AIOKafkaConsumer,
+    mock_slack: MockSlackWebhook,
+    mock_qserv: MockQserv,
+    redis: RedisContainer,
+) -> None:
+    async with LifespanManager(app):
+        factory = context_dependency.create_factory()
+        arq_worker = create_arq_worker(factory._context)
+
+        job = await start_query(kafka_broker, "data-wrong-schema")
+        status = await wait_for_status(kafka_status_consumer, "data-started")
+        assert status.query_info
+        start_time = status.query_info.start_time
+
+        await mock_qserv.store_results(job)
+        qserv_status = read_test_qserv_status(
+            "data-completed",
+            query_begin=start_time,
+            last_update=datetime.now(tz=UTC).replace(microsecond=0),
+        )
+        await mock_qserv.update_status(1, qserv_status)
+
+        await wait_for_dispatch(factory, 1)
+
+        # Run the background task queue.
+        assert await arq_worker.run_check() == 1
+        await wait_for_status(kafka_status_consumer, "data-wrong-schema")
+
+    # Ensure all query state has been deleted.
+    redis_client = redis.get_client()
+    assert set(redis_client.scan_iter("query:*")) == set()
+
+    # Check that a Slack message was posted about the encoding error.
+    data.assert_json_matches(mock_slack.messages, "slack/wrong-schema")


### PR DESCRIPTION
If the underlying database schema does not match the VOTable schema, the error may show up during pack. Python's pack built-in returns opaque and unhelpful error messages that are not caught elsewhere in qserv-kafka, causing the job to essentially disappear and never be completed from the TAP server perspective.

Catch encoding errors and transform them into a proper exception that can be returned as an error to the user and reported. Include the column name and data type in the reported exception to make tracking down the incorrect schema easier.

This change only catches BINARY2 encoding errors, not Parquet encoding errors, since it was not as obvious where to catch errors in the latter and how to get the column information.