### PR TITLE
DM-55463: Fix periodic CI configuration

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -24,11 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: ".python-version"
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -38,7 +33,7 @@ jobs:
         run: make update-deps
 
       - name: Run nox
-        run: uv run --only-group=nox nox run -s lint typing test
+        run: uv run --only-group=nox nox -s lint typing test
 
       - name: Report status
         if: failure()


### PR DESCRIPTION
Use the correct syntax for invoking nox and remove the setup-python step that setup-uv handles.