### PR TITLE
DM-55463: Convert the test suite to safir.testing.data

### DIFF
--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -421,8 +421,6 @@ JobTableUpload = Annotated[
 class JobMetadata(BaseModel):
     """Metadata about a query."""
 
-    model_config = ConfigDict(serialize_by_alias=True)
-
     query: Annotated[
         str,
         Field(
@@ -545,7 +543,7 @@ class JobRun(BaseModel):
 class JobQueryInfo(BaseModel):
     """Information about the status of an executing query."""
 
-    model_config = ConfigDict(serialize_by_alias=True)
+    model_config = ConfigDict(serialize_by_alias=True, validate_by_name=True)
 
     start_time: Annotated[
         DatetimeMillis,
@@ -553,6 +551,7 @@ class JobQueryInfo(BaseModel):
             title="Start time",
             description="When the job started executing",
             serialization_alias="startTime",
+            validation_alias="startTime",
         ),
     ]
 
@@ -562,6 +561,7 @@ class JobQueryInfo(BaseModel):
             title="Completion time",
             description="When the job completed",
             serialization_alias="endTime",
+            validation_alias="endTime",
         ),
     ] = None
 
@@ -577,7 +577,7 @@ class JobQueryInfo(BaseModel):
 class JobResultInfo(BaseModel):
     """Result of a query."""
 
-    model_config = ConfigDict(serialize_by_alias=True)
+    model_config = ConfigDict(serialize_by_alias=True, validate_by_name=True)
 
     total_rows: Annotated[
         int,
@@ -585,6 +585,7 @@ class JobResultInfo(BaseModel):
             title="Output rows",
             description="Total number of rows in the result",
             serialization_alias="totalRows",
+            validation_alias="totalRows",
         ),
     ]
 
@@ -594,6 +595,7 @@ class JobResultInfo(BaseModel):
             title="User-facing URL of results",
             description="Copied from the job request, not used by the bridge",
             serialization_alias="resultLocation",
+            validation_alias="resultLocation",
         ),
     ] = None
 
@@ -619,11 +621,15 @@ class JobErrorCode(StrEnum):
 class JobError(BaseModel):
     """Error from a query."""
 
-    model_config = ConfigDict(serialize_by_alias=True)
+    model_config = ConfigDict(serialize_by_alias=True, validate_by_name=True)
 
     code: Annotated[
         JobErrorCode,
-        Field(title="Error code", serialization_alias="errorCode"),
+        Field(
+            title="Error code",
+            serialization_alias="errorCode",
+            validation_alias="errorCode",
+        ),
     ]
 
     message: Annotated[
@@ -632,6 +638,7 @@ class JobError(BaseModel):
             title="Error message",
             description="Human-readable error message",
             serialization_alias="errorMessage",
+            validation_alias="errorMessage",
         ),
     ]
 
@@ -639,7 +646,7 @@ class JobError(BaseModel):
 class JobStatus(BaseModel):
     """Status of a TAP query."""
 
-    model_config = ConfigDict(serialize_by_alias=True)
+    model_config = ConfigDict(serialize_by_alias=True, validate_by_name=True)
 
     job_id: Annotated[
         str,
@@ -647,6 +654,7 @@ class JobStatus(BaseModel):
             title="UWS job ID",
             description="Identifier of job in the TAP server's UWS database",
             serialization_alias="jobID",
+            validation_alias="jobID",
         ),
     ]
 
@@ -656,6 +664,7 @@ class JobStatus(BaseModel):
             title="Backend execution ID",
             description="Identifier of the running query in the backend",
             serialization_alias="executionID",
+            validation_alias="executionID",
         ),
     ] = None
 
@@ -677,7 +686,11 @@ class JobStatus(BaseModel):
 
     query_info: Annotated[
         JobQueryInfo | None,
-        Field(title="Query information", serialization_alias="queryInfo"),
+        Field(
+            title="Query information",
+            serialization_alias="queryInfo",
+            validation_alias="queryInfo",
+        ),
     ] = None
 
     result_info: Annotated[
@@ -686,6 +699,7 @@ class JobStatus(BaseModel):
             title="Job result",
             description="Result of the job if it has completed",
             serialization_alias="resultInfo",
+            validation_alias="resultInfo",
         ),
     ] = None
 
@@ -695,6 +709,7 @@ class JobStatus(BaseModel):
             title="Job error",
             description="Error for the job if the job failed",
             serialization_alias="errorInfo",
+            validation_alias="errorInfo",
         ),
     ] = None
 

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -84,8 +84,9 @@ class QueryMonitor:
         query
             Running query information.
         status
-            Backend status from the running process list, if the query appeared
-            there, or `None` otherwise.
+            Backend status from the running process list, if the query
+            appeared there, or `None` otherwise. If `None`, the job will be
+            assumed to be complete.
 
         Returns
         -------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ from safir.database import create_database_engine
 from safir.kafka import KafkaConnectionSettings, SecurityProtocol
 from safir.logging import configure_logging
 from safir.testing.containers import FullKafkaContainer
-from safir.testing.data import Data
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from sqlalchemy.ext.asyncio import AsyncEngine
 from structlog.stdlib import BoundLogger, get_logger
@@ -32,6 +31,7 @@ from qservkafka.config import config
 from qservkafka.factory import Factory, ProcessContext
 from qservkafka.main import create_app
 
+from .support.data import QservKafkaData
 from .support.qserv import MockQserv, register_mock_qserv
 
 
@@ -74,9 +74,11 @@ async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
 
 
 @pytest.fixture
-def data(request: pytest.FixtureRequest) -> Data:
+def data(request: pytest.FixtureRequest) -> QservKafkaData:
     update = request.config.getoption("--update-test-data")
-    return Data(Path(__file__).parent / "data", update_test_data=update)
+    return QservKafkaData(
+        Path(__file__).parent / "data", update_test_data=update
+    )
 
 
 @pytest_asyncio.fixture
@@ -220,6 +222,7 @@ async def mock_gafaelfawr(
 @pytest_asyncio.fixture(ids=["good"], params=[False])
 async def mock_qserv(
     *,
+    data: QservKafkaData,
     respx_mock: respx.Router,
     engine: AsyncEngine,
     request: pytest.FixtureRequest,
@@ -245,9 +248,12 @@ async def mock_qserv(
     if request.param:
         delay = timedelta(milliseconds=10)
         monkeypatch.setattr(config, "backend_retry_delay", delay)
-    url = str(config.qserv_rest_url)
     async with register_mock_qserv(
-        respx_mock, url, engine, flaky=request.param
+        data,
+        respx_mock,
+        engine,
+        base_url=str(config.qserv_rest_url),
+        flaky=request.param,
     ) as mock_qserv:
         yield mock_qserv
 

--- a/tests/data/status/data-completed.json
+++ b/tests/data/status/data-completed.json
@@ -1,26 +1,26 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "COMPLETED",
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 10
-    }
-  },
-  "result_info": {
-    "total_rows": 2,
-    "result_location": "https://gcs.example.com/upload",
-    "format": {
-      "type": "VOTable",
-      "serialization": "BINARY2"
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 10,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "resultInfo": {
+    "format": {
+      "serialization": "BINARY2",
+      "type": "VOTable"
+    },
+    "resultLocation": "https://gcs.example.com/upload",
+    "totalRows": 2
+  },
+  "status": "COMPLETED",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/data-maxrec-completed.json
+++ b/tests/data/status/data-maxrec-completed.json
@@ -1,26 +1,26 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "COMPLETED",
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 10
-    }
-  },
-  "result_info": {
-    "total_rows": 1,
-    "result_location": "https://gcs.example.com/upload",
-    "format": {
-      "type": "VOTable",
-      "serialization": "BINARY2"
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 10,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "resultInfo": {
+    "format": {
+      "serialization": "BINARY2",
+      "type": "VOTable"
+    },
+    "resultLocation": "https://gcs.example.com/upload",
+    "totalRows": 1
+  },
+  "status": "COMPLETED",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/data-overquota.json
+++ b/tests/data/status/data-overquota.json
@@ -1,13 +1,13 @@
 {
-  "job_id": "uws123",
-  "timestamp": 1743540791,
-  "status": "ERROR",
-  "error": {
-    "code": "quota_exceeded",
-    "message": "Maximum running queries reached (2 running, maximum 2); wait for a query to finish or cancel one of your running queries"
+  "errorInfo": {
+    "errorCode": "quota_exceeded",
+    "errorMessage": "Maximum running queries reached (2 running, maximum 2); wait for a query to finish or cancel one of your running queries"
   },
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "status": "ERROR",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/data-started.json
+++ b/tests/data/status/data-started.json
@@ -1,17 +1,17 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "EXECUTING",
-  "query_info": {
-    "start_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 0
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "progress": {
+      "completedChunks": 0,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "EXECUTING",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/data-wrong-schema.json
+++ b/tests/data/status/data-wrong-schema.json
@@ -1,14 +1,14 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "ERROR",
-  "error": {
-    "code": "encoding_error",
-    "message": "Error encoding h: error: 'l' format requires -2147483648 <= number <= 2147483647"
+  "errorInfo": {
+    "errorCode": "encoding_error",
+    "errorMessage": "Error encoding h: error: 'l' format requires -2147483648 <= number <= 2147483647"
   },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "status": "ERROR",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/data-zero-completed.json
+++ b/tests/data/status/data-zero-completed.json
@@ -1,26 +1,26 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "COMPLETED",
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 10
-    }
-  },
-  "result_info": {
-    "total_rows": 0,
-    "result_location": "https://gcs.example.com/upload",
-    "format": {
-      "type": "VOTable",
-      "serialization": "BINARY2"
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 10,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "resultInfo": {
+    "format": {
+      "serialization": "BINARY2",
+      "type": "VOTable"
+    },
+    "resultLocation": "https://gcs.example.com/upload",
+    "totalRows": 0
+  },
+  "status": "COMPLETED",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/simple-aborted.json
+++ b/tests/data/status/simple-aborted.json
@@ -1,18 +1,18 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540792,
-  "status": "ABORTED",
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540792,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 0
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 0,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "ABORTED",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/simple-error.json
+++ b/tests/data/status/simple-error.json
@@ -1,14 +1,14 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "ERROR",
-  "error": {
-    "code": "backend_error",
-    "message": "Qserv request failed: Some error"
+  "errorInfo": {
+    "errorCode": "backend_error",
+    "errorMessage": "Qserv request failed: Some error"
   },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "status": "ERROR",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/simple-failed.json
+++ b/tests/data/status/simple-failed.json
@@ -1,22 +1,22 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "ERROR",
-  "error": {
-    "code": "backend_error",
-    "message": "Query failed in backend: Some Qserv error"
+  "errorInfo": {
+    "errorCode": "backend_error",
+    "errorMessage": "Query failed in backend: Some Qserv error"
   },
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540819,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 8
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 8,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "ERROR",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/simple-large.json
+++ b/tests/data/status/simple-large.json
@@ -1,22 +1,22 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "ERROR",
-  "error": {
-    "code": "backend_results_too_large",
-    "message": "Query results are too large to return; please narrow your query and try again: MERGE_ERROR 1470 (QI=404591:81; cancelling the query, queryResult table result_404591 is too large at 571829258 bytes, max allowed size is 536870912 bytes) 2025-07-21T05:36:23+0000"
+  "errorInfo": {
+    "errorCode": "backend_results_too_large",
+    "errorMessage": "Query results are too large to return; please narrow your query and try again: MERGE_ERROR 1470 (QI=404591:81; cancelling the query, queryResult table result_404591 is too large at 571829258 bytes, max allowed size is 536870912 bytes) 2025-07-21T05:36:23+0000"
   },
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540819,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 8
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 8,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "ERROR",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/simple-partial.json
+++ b/tests/data/status/simple-partial.json
@@ -1,17 +1,17 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "EXECUTING",
-  "query_info": {
-    "start_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 5
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "progress": {
+      "completedChunks": 5,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "EXECUTING",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/simple-started.json
+++ b/tests/data/status/simple-started.json
@@ -1,17 +1,17 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "EXECUTING",
-  "query_info": {
-    "start_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 0
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
-    "query": "SELECT TOP 10 * FROM table",
-    "database": "dp1"
-  }
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "progress": {
+      "completedChunks": 0,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "EXECUTING",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/upload-completed.json
+++ b/tests/data/status/upload-completed.json
@@ -1,25 +1,25 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "COMPLETED",
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 10
-    }
-  },
-  "result_info": {
-    "total_rows": 2,
-    "result_location": "https://gcs.example.com/upload",
-    "format": {
-      "type": "VOTable",
-      "serialization": "BINARY2"
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
     "query": "SELECT TOP 10 * FROM user_username.table"
-  }
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 10,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "resultInfo": {
+    "format": {
+      "serialization": "BINARY2",
+      "type": "VOTable"
+    },
+    "resultLocation": "https://gcs.example.com/upload",
+    "totalRows": 2
+  },
+  "status": "COMPLETED",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/upload-failed.json
+++ b/tests/data/status/upload-failed.json
@@ -1,21 +1,21 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "ERROR",
-  "error": {
-    "code": "backend_error",
-    "message": "Query failed in backend"
+  "errorInfo": {
+    "errorCode": "backend_error",
+    "errorMessage": "Query failed in backend"
   },
-  "query_info": {
-    "start_time": 1743540791,
-    "end_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 8
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
     "query": "SELECT TOP 10 * FROM user_username.table"
-  }
+  },
+  "queryInfo": {
+    "endTime": "<ANY>",
+    "progress": {
+      "completedChunks": 8,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "ERROR",
+  "timestamp": "<ANY>"
 }

--- a/tests/data/status/upload-started.json
+++ b/tests/data/status/upload-started.json
@@ -1,16 +1,16 @@
 {
-  "job_id": "uws123",
-  "execution_id": "1",
-  "timestamp": 1743540791,
-  "status": "EXECUTING",
-  "query_info": {
-    "start_time": 1743540791,
-    "progress": {
-      "total_chunks": 10,
-      "completed_chunks": 0
-    }
-  },
+  "executionID": "1",
+  "jobID": "uws123",
   "metadata": {
     "query": "SELECT TOP 10 * FROM user_username.table"
-  }
+  },
+  "queryInfo": {
+    "progress": {
+      "completedChunks": 0,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "EXECUTING",
+  "timestamp": "<ANY>"
 }

--- a/tests/kafka/leak_test.py
+++ b/tests/kafka/leak_test.py
@@ -24,7 +24,7 @@ from qservkafka.dependencies.context import context_dependency
 from qservkafka.factory import Factory
 
 from ..support.arq import create_arq_worker
-from ..support.data import read_test_qserv_status
+from ..support.data import QservKafkaData
 from ..support.kafka import start_query, wait_for_dispatch, wait_for_status
 from ..support.qserv import MockQserv
 
@@ -54,6 +54,7 @@ def set_log_level(monkeypatch: pytest.MonkeyPatch) -> None:
 
 async def run_job(
     *,
+    data: QservKafkaData,
     factory: Factory,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -62,15 +63,18 @@ async def run_job(
     execution_id: int,
 ) -> None:
     """Run a single job end-to-end."""
-    job = await start_query(kafka_broker, "data")
+    job = await start_query(data, kafka_broker, "data")
     status = await wait_for_status(
-        kafka_status_consumer, "data-started", execution_id=str(execution_id)
+        data,
+        kafka_status_consumer,
+        "data-started",
+        execution_id=str(execution_id),
     )
     assert status.query_info
     start_time = status.query_info.start_time
     await mock_qserv.store_results(job)
-    qserv_status = read_test_qserv_status(
-        "data-completed",
+    qserv_status = data.read_qserv_status(
+        "qserv/data-completed",
         query_id=execution_id,
         query_begin=start_time,
         last_update=datetime.now(tz=UTC),
@@ -79,7 +83,10 @@ async def run_job(
     await wait_for_dispatch(factory, execution_id)
     assert await arq_worker.run_check() == execution_id
     await wait_for_status(
-        kafka_status_consumer, "data-completed", execution_id=str(execution_id)
+        data,
+        kafka_status_consumer,
+        "data-completed",
+        execution_id=str(execution_id),
     )
 
 
@@ -87,6 +94,7 @@ async def run_job(
 @pytest.mark.timeout(120)
 async def test_leak(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -102,6 +110,7 @@ async def test_leak(
         # Run a single job to force any memory allocations that only happen
         # once, during the first job.
         await run_job(
+            data=data,
             factory=factory,
             kafka_broker=kafka_broker,
             kafka_status_consumer=kafka_status_consumer,
@@ -118,6 +127,7 @@ async def test_leak(
         # Run 100 jobs through the system end to end.
         for i in range(2, 102):
             await run_job(
+                data=data,
                 factory=factory,
                 kafka_broker=kafka_broker,
                 kafka_status_consumer=kafka_status_consumer,

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -17,20 +17,16 @@ from rubin.gafaelfawr import (
     MockGafaelfawr,
 )
 from safir.metrics import MockEventPublisher
-from safir.testing.data import Data
 from safir.testing.slack import MockSlackWebhook
 from testcontainers.redis import RedisContainer
 
 from qservkafka.config import config
 from qservkafka.dependencies.context import context_dependency
+from qservkafka.models.kafka import JobRun
 from qservkafka.models.state import RunningQuery
 
 from ..support.arq import create_arq_worker
-from ..support.data import (
-    read_test_job_cancel,
-    read_test_job_run,
-    read_test_qserv_status,
-)
+from ..support.data import QservKafkaData
 from ..support.kafka import start_query, wait_for_dispatch, wait_for_status
 from ..support.qserv import MockQserv
 
@@ -42,6 +38,7 @@ from ..support.qserv import MockQserv
 )
 async def test_success(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -53,14 +50,16 @@ async def test_success(
         arq_worker = create_arq_worker(factory._context)
 
         start = datetime.now(tz=UTC)
-        job = await start_query(kafka_broker, "data")
-        status = await wait_for_status(kafka_status_consumer, "data-started")
+        job = await start_query(data, kafka_broker, "data")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "data-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
 
         await mock_qserv.store_results(job)
-        qserv_status = read_test_qserv_status(
-            "data-completed",
+        qserv_status = data.read_qserv_status(
+            "qserv/data-completed",
             query_begin=start_time,
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
@@ -70,7 +69,9 @@ async def test_success(
 
         # Run the background task queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(kafka_status_consumer, "data-completed")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "data-completed"
+        )
         assert status.query_info
         assert status.query_info.start_time == start_time
         assert status.query_info.end_time
@@ -110,6 +111,7 @@ async def test_success(
 @pytest.mark.timeout(60)
 async def test_failure(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -120,31 +122,37 @@ async def test_failure(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        await start_query(kafka_broker, "simple")
-        status = await wait_for_status(kafka_status_consumer, "simple-started")
+        await start_query(data, kafka_broker, "simple")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
 
         now = datetime.now(tz=UTC).replace(microsecond=0)
-        qserv_status = read_test_qserv_status(
-            "simple-partial", query_begin=start_time, last_update=now
+        qserv_status = data.read_qserv_status(
+            "qserv/simple-partial", query_begin=start_time, last_update=now
         )
         await mock_qserv.update_status(1, qserv_status)
-        status = await wait_for_status(kafka_status_consumer, "simple-partial")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-partial"
+        )
         assert status.timestamp == now
         assert status.query_info
         assert status.query_info.start_time == start_time
 
         now = datetime.now(tz=UTC).replace(microsecond=0)
-        qserv_status = read_test_qserv_status(
-            "simple-failed", query_begin=start_time, last_update=now
+        qserv_status = data.read_qserv_status(
+            "qserv/simple-failed", query_begin=start_time, last_update=now
         )
         await mock_qserv.update_status(1, qserv_status)
         await wait_for_dispatch(factory, 1)
 
         # Run the background tsk queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(kafka_status_consumer, "simple-failed")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-failed"
+        )
         assert status.timestamp == now
         assert status.query_info
         assert status.query_info.start_time == start_time
@@ -160,6 +168,7 @@ async def test_failure(
 @pytest.mark.timeout(60)
 async def test_too_large(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -170,21 +179,25 @@ async def test_too_large(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        await start_query(kafka_broker, "simple")
-        status = await wait_for_status(kafka_status_consumer, "simple-started")
+        await start_query(data, kafka_broker, "simple")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
 
         now = datetime.now(tz=UTC).replace(microsecond=0)
-        qserv_status = read_test_qserv_status(
-            "simple-large", query_begin=start_time, last_update=now
+        qserv_status = data.read_qserv_status(
+            "qserv/simple-large", query_begin=start_time, last_update=now
         )
         await mock_qserv.update_status(1, qserv_status)
         await wait_for_dispatch(factory, 1)
 
         # Run the background tsk queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(kafka_status_consumer, "simple-large")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-large"
+        )
         assert status.timestamp == now
         assert status.query_info
         assert status.query_info.start_time == start_time
@@ -200,6 +213,7 @@ async def test_too_large(
 @pytest.mark.timeout(60)
 async def test_qserv_error(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -215,15 +229,17 @@ async def test_qserv_error(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        await start_query(kafka_broker, "simple")
-        status = await wait_for_status(kafka_status_consumer, "simple-started")
+        await start_query(data, kafka_broker, "simple")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
 
         error_json = {"success": 0, "error": "Some error"}
         mock_qserv.set_status_response(Response(200, json=error_json))
-        qserv_status = read_test_qserv_status(
-            "simple-completed",
+        qserv_status = data.read_qserv_status(
+            "qserv/simple-completed",
             query_begin=start_time,
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
@@ -232,7 +248,9 @@ async def test_qserv_error(
 
         # Run the background tsk queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(kafka_status_consumer, "simple-error")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-error"
+        )
 
     # Ensure all query state has been deleted.
     redis_client = redis.get_client()
@@ -243,6 +261,7 @@ async def test_qserv_error(
 @pytest.mark.timeout(60)
 async def test_missing_executing(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -252,8 +271,8 @@ async def test_missing_executing(
     """Test queries that are not in the process list but still executing."""
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
-        await start_query(kafka_broker, "data")
-        await wait_for_status(kafka_status_consumer, "data-started")
+        await start_query(data, kafka_broker, "data")
+        await wait_for_status(data, kafka_status_consumer, "data-started")
 
         # Remove the query from the running query list. It should be
         # dispatched to the result worker.
@@ -264,7 +283,7 @@ async def test_missing_executing(
     # status update we already sent (since nothing has changed).
     arq_worker = create_arq_worker()
     assert await arq_worker.run_check() == 1
-    await wait_for_status(kafka_status_consumer, "data-started")
+    await wait_for_status(data, kafka_status_consumer, "data-started")
 
     # The query should still be active and should no longer be marked as
     # dispatched, so it will be checked again the next time through the
@@ -280,22 +299,27 @@ async def test_missing_executing(
 @pytest.mark.timeout(60)
 async def test_cancel(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
     redis: RedisContainer,
 ) -> None:
     async with LifespanManager(app):
-        await start_query(kafka_broker, "simple")
-        status = await wait_for_status(kafka_status_consumer, "simple-started")
+        await start_query(data, kafka_broker, "simple")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
 
         sent_time = datetime.now(tz=UTC)
-        cancel_json = read_test_job_cancel("simple").model_dump(mode="json")
-        await kafka_broker.publish(cancel_json, config.job_cancel_topic)
+        cancel = data.read_json("cancel/simple")
+        await kafka_broker.publish(cancel, config.job_cancel_topic)
 
-        status = await wait_for_status(kafka_status_consumer, "simple-aborted")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "simple-aborted"
+        )
         assert status.query_info
         assert status.query_info.start_time == start_time
         assert status.query_info.end_time
@@ -310,6 +334,7 @@ async def test_cancel(
 @pytest.mark.timeout(60)
 async def test_upload(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -319,17 +344,19 @@ async def test_upload(
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
 
-        job = await start_query(kafka_broker, "upload")
+        job = await start_query(data, kafka_broker, "upload")
         table_name = job.upload_tables[0].table_name
         database_name = job.upload_tables[0].database
-        status = await wait_for_status(kafka_status_consumer, "upload-started")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "upload-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
         assert mock_qserv.get_uploaded_table() == table_name
         assert mock_qserv.get_uploaded_database() == database_name
 
-        qserv_status = read_test_qserv_status(
-            "upload-failed",
+        qserv_status = data.read_qserv_status(
+            "qserv/upload-failed",
             query_begin=start_time,
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
@@ -344,7 +371,7 @@ async def test_upload(
     # Run the backend worker.
     arq_worker = create_arq_worker()
     assert await arq_worker.run_check() == 1
-    await wait_for_status(kafka_status_consumer, "upload-failed")
+    await wait_for_status(data, kafka_status_consumer, "upload-failed")
 
     # Now that results have been processed, the table should be deleted.
     assert mock_qserv.get_uploaded_database() is None
@@ -359,6 +386,7 @@ async def test_upload(
 @pytest.mark.timeout(60)
 async def test_quota(
     *,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -367,7 +395,7 @@ async def test_quota(
     redis: RedisContainer,
 ) -> None:
     redis_client = redis.get_client()
-    job = read_test_job_run("data")
+    job = data.read_pydantic(JobRun, "jobs/data")
     quota = GafaelfawrQuota(
         tap={config.tap_service: GafaelfawrTapQuota(concurrent=2)}
     )
@@ -379,19 +407,21 @@ async def test_quota(
         arq_worker = create_arq_worker(factory._context)
 
         # Start a couple of queries.
-        await start_query(kafka_broker, "data")
-        status = await wait_for_status(kafka_status_consumer, "data-started")
+        await start_query(data, kafka_broker, "data")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "data-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
-        job = await start_query(kafka_broker, "data")
+        job = await start_query(data, kafka_broker, "data")
         await wait_for_status(
-            kafka_status_consumer, "data-started", execution_id="2"
+            data, kafka_status_consumer, "data-started", execution_id="2"
         )
 
         # This should have exhausted the user's quota, and starting a third
         # job should be rejected with an error.
-        await start_query(kafka_broker, "data")
-        await wait_for_status(kafka_status_consumer, "data-overquota")
+        await start_query(data, kafka_broker, "data")
+        await wait_for_status(data, kafka_status_consumer, "data-overquota")
 
         # Make sure that we decremented the counter of running queries again
         # when rejecting that job.
@@ -399,8 +429,8 @@ async def test_quota(
 
         # Let the first query finish.
         await mock_qserv.store_results(job)
-        qserv_status = read_test_qserv_status(
-            "data-completed",
+        qserv_status = data.read_qserv_status(
+            "qserv/data-completed",
             query_begin=start_time,
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
@@ -409,12 +439,12 @@ async def test_quota(
 
         # Run the background task queue.
         assert await arq_worker.run_check() == 1
-        await wait_for_status(kafka_status_consumer, "data-completed")
+        await wait_for_status(data, kafka_status_consumer, "data-completed")
 
         # Now, it should be possible to start a new query.
-        await start_query(kafka_broker, "data")
+        await start_query(data, kafka_broker, "data")
         await wait_for_status(
-            kafka_status_consumer, "data-started", execution_id="3"
+            data, kafka_status_consumer, "data-started", execution_id="3"
         )
         assert redis_client.get(f"rate:{job.owner}") == b"2"
 
@@ -423,7 +453,7 @@ async def test_quota(
 @pytest.mark.timeout(40)
 async def test_wrong_schema(
     *,
-    data: Data,
+    data: QservKafkaData,
     app: FastAPI,
     kafka_broker: KafkaBroker,
     kafka_status_consumer: AIOKafkaConsumer,
@@ -435,14 +465,16 @@ async def test_wrong_schema(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        job = await start_query(kafka_broker, "data-wrong-schema")
-        status = await wait_for_status(kafka_status_consumer, "data-started")
+        job = await start_query(data, kafka_broker, "data-wrong-schema")
+        status = await wait_for_status(
+            data, kafka_status_consumer, "data-started"
+        )
         assert status.query_info
         start_time = status.query_info.start_time
 
         await mock_qserv.store_results(job)
-        qserv_status = read_test_qserv_status(
-            "data-completed",
+        qserv_status = data.read_qserv_status(
+            "qserv/data-completed",
             query_begin=start_time,
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
@@ -452,7 +484,7 @@ async def test_wrong_schema(
 
         # Run the background task queue.
         assert await arq_worker.run_check() == 1
-        await wait_for_status(kafka_status_consumer, "data-wrong-schema")
+        await wait_for_status(data, kafka_status_consumer, "data-wrong-schema")
 
     # Ensure all query state has been deleted.
     redis_client = redis.get_client()

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -11,9 +11,11 @@ from vo_models.uws.types import ExecutionPhase
 from qservkafka.config import config
 from qservkafka.factory import Factory
 from qservkafka.models.kafka import (
+    JobCancel,
     JobError,
     JobErrorCode,
     JobQueryInfo,
+    JobRun,
     JobStatus,
 )
 from qservkafka.models.progress import ChunkProgress
@@ -21,7 +23,7 @@ from qservkafka.models.qserv import QservAsyncStatusData, QservQueryPhase
 from qservkafka.storage import qserv
 
 from ..support.constants import ANY_DATETIME, ANY_STRING
-from ..support.data import read_test_job_cancel, read_test_job_run
+from ..support.data import QservKafkaData
 from ..support.datetime import assert_approximately_now
 from ..support.qserv import MockQserv
 
@@ -30,8 +32,10 @@ from ..support.qserv import MockQserv
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
-    job = read_test_job_run("simple")
+async def test_start_errors(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
+    job = data.read_pydantic(JobRun, "jobs/simple")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
 
@@ -78,8 +82,10 @@ async def test_start_errors(factory: Factory, mock_qserv: MockQserv) -> None:
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
-    job = read_test_job_run("simple")
+async def test_status_errors(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
+    job = data.read_pydantic(JobRun, "jobs/simple")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC).replace(microsecond=0)
@@ -175,12 +181,14 @@ async def test_status_errors(factory: Factory, mock_qserv: MockQserv) -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_start_invalid(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     now = datetime.now(tz=UTC).replace(microsecond=0)
 
-    job = read_test_job_run("tabledata")
+    job = data.read_pydantic(JobRun, "jobs/tabledata")
     status = await query_service.start_query(job)
     expected = JobStatus(
         job_id=job.job_id,
@@ -197,7 +205,7 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
     assert expected.error
     assert status == expected
 
-    job = read_test_job_run("arraysize")
+    job = data.read_pydantic(JobRun, "jobs/arraysize")
     status = await query_service.start_query(job)
     expected = JobStatus(
         job_id=job.job_id,
@@ -220,10 +228,12 @@ async def test_start_invalid(factory: Factory, mock_qserv: MockQserv) -> None:
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_sql_failure(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("data")
+    job = data.read_pydantic(JobRun, "jobs/data")
     now = datetime.now(tz=UTC).replace(microsecond=0)
 
     mock_qserv.set_immediate_success(job)
@@ -250,7 +260,11 @@ async def test_sql_failure(factory: Factory, mock_qserv: MockQserv) -> None:
 
 @pytest.mark.asyncio
 async def test_upload_timeout(
-    factory: Factory, mock_qserv: MockQserv, monkeypatch: pytest.MonkeyPatch
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test handling of a timeout during results uploading.
 
@@ -258,7 +272,7 @@ async def test_upload_timeout(
     """
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("data")
+    job = data.read_pydantic(JobRun, "jobs/data")
 
     mock_qserv.set_immediate_success(job)
     mock_qserv.set_upload_delay(timedelta(seconds=2))
@@ -284,9 +298,9 @@ async def test_upload_timeout(
 
 
 @pytest.mark.asyncio
-async def test_cancel_unknown(factory: Factory) -> None:
+async def test_cancel_unknown(data: QservKafkaData, factory: Factory) -> None:
     """Test canceling an unknown job."""
     query_service = factory.create_query_service()
-    cancel = read_test_job_cancel("simple")
+    cancel = data.read_pydantic(JobCancel, "cancel/simple")
 
     assert await query_service.cancel_query(cancel) is None

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -16,8 +16,9 @@ from safir.metrics import metrics_configuration_factory
 
 from qservkafka.config import config
 from qservkafka.factory import Factory
+from qservkafka.models.kafka import JobRun
 
-from ..support.data import read_test_job_run, read_test_job_status
+from ..support.data import QservKafkaData
 from ..support.qserv import MockQserv
 
 
@@ -47,6 +48,7 @@ def set_log_level(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.asyncio
 async def test_success(
     *,
+    data: QservKafkaData,
     factory: Factory,
     mock_qserv: MockQserv,
     respx_mock: respx.Router,
@@ -55,14 +57,12 @@ async def test_success(
     """Test for memory leaks in the immediate job processing flow."""
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("data")
-    expected_status = read_test_job_status("data-completed")
+    job = data.read_pydantic(JobRun, "jobs/data")
     mock_qserv.set_immediate_success(job)
 
     # Run one query first to set up the various internal Python caches.
     status = await query_service.start_query(job)
-    expected_status.execution_id = "1"
-    assert status == expected_status
+    data.assert_job_status_matches(status, "status/data-completed")
 
     # Start tracing memory.
     gc.collect()
@@ -72,8 +72,9 @@ async def test_success(
     # Run 100 more tasks with memory tracing.
     for i in range(2, 102):
         status = await query_service.start_query(job)
-        expected_status.execution_id = str(i)
-        assert status == expected_status
+        data.assert_job_status_matches(
+            status, "status/data-completed", execution_id=str(i)
+        )
 
     # Ensure all the queries have been processed.
     assert await state_store.get_active_queries() == set()

--- a/tests/services/monitor_test.py
+++ b/tests/services/monitor_test.py
@@ -8,12 +8,9 @@ from safir.arq import RedisArqQueue
 from testcontainers.redis import RedisContainer
 
 from qservkafka.factory import Factory
+from qservkafka.models.kafka import JobRun
 
-from ..support.data import (
-    read_test_job_run,
-    read_test_job_status,
-    read_test_qserv_status,
-)
+from ..support.data import QservKafkaData
 from ..support.qserv import MockQserv
 
 
@@ -21,20 +18,21 @@ from ..support.qserv import MockQserv
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_dispatch(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_dispatch(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     monitor = await factory.create_query_monitor()
-    job = read_test_job_run("simple")
-    expected_status = read_test_job_status("simple-started")
+    job = data.read_pydantic(JobRun, "jobs/simple")
 
     status = await query_service.start_query(job)
-    assert status == expected_status
+    data.assert_job_status_matches(status, "status/simple-started")
 
     qserv_status = mock_qserv.get_status(1)
     now = datetime.now(tz=UTC).replace(microsecond=0)
-    qserv_status = read_test_qserv_status(
-        "simple-completed",
+    qserv_status = data.read_qserv_status(
+        "qserv/simple-completed",
         query_begin=qserv_status.query_begin,
         last_update=now,
     )
@@ -44,8 +42,7 @@ async def test_dispatch(factory: Factory, mock_qserv: MockQserv) -> None:
     assert query
     qserv_status = mock_qserv.get_status(1)
     with patch.object(RedisArqQueue, "enqueue") as mock:
-        # Pass None to let monitor fetch status from backend
-        assert await monitor.check_query(query, None) is None
+        assert await monitor.check_query(query, status=None) is None
         assert mock.call_args_list == [call("handle_finished_query", "1")]
         mock.reset_mock()
 
@@ -54,28 +51,31 @@ async def test_dispatch(factory: Factory, mock_qserv: MockQserv) -> None:
         # should not dispatch it again.
         query = await state_store.get_query(str(1))
         assert query
-        # Pass None to let monitor fetch status from backend
-        assert await monitor.check_query(query, None) is None
+        assert await monitor.check_query(query, status=None) is None
         assert mock.call_args_list == []
 
 
 @pytest.mark.asyncio
 async def test_quota(
-    factory: Factory, mock_qserv: MockQserv, redis: RedisContainer
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    redis: RedisContainer,
 ) -> None:
     redis_client = redis.get_client()
     query_service = factory.create_query_service()
     monitor = await factory.create_query_monitor()
-    job = read_test_job_run("simple")
-    expected_status = read_test_job_status("simple-started")
+    job = data.read_pydantic(JobRun, "jobs/simple")
     redis_key = f"rate:{job.owner}"
 
     # Start a couple of jobs.
     status = await query_service.start_query(job)
-    assert status == expected_status
+    data.assert_job_status_matches(status, "status/simple-started")
     status = await query_service.start_query(job)
-    expected_status.execution_id = "2"
-    assert status == expected_status
+    data.assert_job_status_matches(
+        status, "status/simple-started", execution_id="2"
+    )
 
     # Check that the rate limit information is correct in Redis.
     assert redis_client.get(redis_key) == b"2"

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -12,62 +12,61 @@ from vo_models.uws.types import ExecutionPhase
 
 from qservkafka.config import config
 from qservkafka.factory import Factory
-from qservkafka.models.kafka import JobErrorCode, JobRun, JobStatus
+from qservkafka.models.kafka import JobCancel, JobErrorCode, JobRun
 from qservkafka.services.query import QueryService
 
-from ..support.data import (
-    read_test_data,
-    read_test_job_cancel,
-    read_test_job_run,
-    read_test_job_status,
-    read_test_qserv_status,
-)
+from ..support.data import QservKafkaData
 from ..support.datetime import assert_approximately_now
 from ..support.qserv import MockQserv
 
 
 async def assert_query_successful(
     *,
+    data: QservKafkaData,
     query_service: QueryService,
     mock_qserv: MockQserv,
     job: JobRun,
-    expected_status: JobStatus,
+    status: str,
+    execution_id: str | None = None,
 ) -> None:
     """Run a query to completion with immediate results.
 
     Parameters
     ----------
+    data
+        Test data management.
     query_service
         Query service to test.
     mock_qserv
         Qserv mock.
     job
         Model of job to run.
-    expected_status
-        Model of status to expect.
+    status
+        Path to status to expect.
+    execution_id
+        Expected execution ID for the job status.
     """
     mock_qserv.set_immediate_success(job)
     kafka_timestamp = datetime.now(tz=UTC) - timedelta(seconds=10)
-    status = await query_service.start_query(job, kafka_timestamp)
-    assert status == expected_status
-    assert_approximately_now(status.timestamp)
-    assert status.query_info
-    assert_approximately_now(status.query_info.start_time)
-    assert_approximately_now(status.query_info.end_time)
+    result = await query_service.start_query(job, kafka_timestamp)
+    data.assert_job_status_matches(result, status, execution_id=execution_id)
+    assert_approximately_now(result.timestamp)
+    assert result.query_info
+    assert_approximately_now(result.query_info.start_time)
+    assert_approximately_now(result.query_info.end_time)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_start(factory: Factory) -> None:
-    job = read_test_job_run("simple")
-    expected_status = read_test_job_status("simple-started")
+async def test_start(data: QservKafkaData, factory: Factory) -> None:
+    job = data.read_pydantic(JobRun, "jobs/simple")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
 
     status = await query_service.start_query(job)
-    assert status == expected_status
+    data.assert_job_status_matches(status, "status/simple-started")
     assert_approximately_now(status.timestamp)
     assert status.query_info
     assert_approximately_now(status.query_info.start_time)
@@ -79,19 +78,21 @@ async def test_start(factory: Factory) -> None:
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_immediate(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     """Test a job that completes immediately."""
     query_service = factory.create_query_service()
-    job = read_test_job_run("data")
-    expected_status = read_test_job_status("data-completed")
+    job = data.read_pydantic(JobRun, "jobs/data")
     state_store = factory.create_query_state_store()
 
     start = datetime.now(tz=UTC)
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-completed",
     )
     finish = datetime.now(tz=UTC)
     elapsed = finish - start
@@ -103,8 +104,8 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     assert isinstance(factory.events.qserv_success, MockEventPublisher)
     events = factory.events.qserv_success.published
     assert len(events) == 1
-    success_event = events[0]
-    assert success_event.model_dump(mode="json") == {
+    event = events[0]
+    assert event.model_dump(mode="json") == {
         "job_id": job.job_id,
         "username": job.owner,
         "elapsed": ANY,
@@ -116,18 +117,15 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
         "rows": 2,
         "qserv_size": 250,
         "qserv_rate": None,
-        "encoded_size": len(read_test_data("results/data.binary2")),
+        "encoded_size": len(data.read_text("results/data.binary2")),
         "result_size": (
-            len(read_test_data("results/data.binary2"))
+            len(data.read_text("results/data.binary2"))
             + len(job.result_format.envelope.header)
             + len(job.result_format.envelope.footer)
         ),
-        "rate": (
-            success_event.encoded_size / success_event.elapsed.total_seconds()
-        ),
+        "rate": event.encoded_size / event.elapsed.total_seconds(),
         "result_rate": (
-            success_event.encoded_size
-            / success_event.result_elapsed.total_seconds()
+            event.encoded_size / event.result_elapsed.total_seconds()
         ),
         "upload_tables": 0,
         "immediate": True,
@@ -135,7 +133,7 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
 
     # These time fields should include the fake Kafka delay of 10s.
     for field in ("elapsed", "kafka_elapsed"):
-        timestamp = getattr(success_event, field)
+        timestamp = getattr(event, field)
         assert timedelta(seconds=10) <= timestamp
         assert timestamp <= elapsed + timedelta(seconds=10)
 
@@ -146,20 +144,21 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
         "submit_elapsed",
         "delete_elapsed",
     ):
-        assert timedelta(seconds=0) <= getattr(success_event, field) <= elapsed
+        assert timedelta(seconds=0) <= getattr(event, field) <= elapsed
 
     # It should be possible to immediately run the same query again. This
     # tests that the results were deleted from the database, and thus can be
     # re-added.
-    assert expected_status.execution_id
-    expected_status.execution_id = str(int(expected_status.execution_id) + 1)
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-completed",
+        execution_id="2",
     )
 
+    # All queries should have completed.
     assert await state_store.get_active_queries() == set()
 
     # If Qserv was configured to intermittently fail, check that we logged
@@ -176,19 +175,23 @@ async def test_immediate(factory: Factory, mock_qserv: MockQserv) -> None:
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_no_delete(
-    factory: Factory, mock_qserv: MockQserv, monkeypatch: pytest.MonkeyPatch
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that deleting results from Qserv can be configured."""
     monkeypatch.setattr(config, "qserv_delete_queries", False)
     query_service = factory.create_query_service()
-    job = read_test_job_run("data")
-    expected_status = read_test_job_status("data-completed")
+    job = data.read_pydantic(JobRun, "jobs/data")
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-completed",
     )
 
     # Check that the query was not deleted.
@@ -210,7 +213,7 @@ async def test_no_delete(
         "rows": 2,
         "qserv_size": 250,
         "qserv_rate": ANY,
-        "encoded_size": len(read_test_data("results/data.binary2")),
+        "encoded_size": len(data.read_text("results/data.binary2")),
         "result_size": ANY,
         "rate": ANY,
         "result_rate": ANY,
@@ -223,32 +226,31 @@ async def test_no_delete(
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_cancel(factory: Factory) -> None:
-    job = read_test_job_run("simple")
-    started_status = read_test_job_status("simple-started")
-    cancel = read_test_job_cancel("simple")
-    canceled_status = read_test_job_status("simple-aborted")
+async def test_cancel(data: QservKafkaData, factory: Factory) -> None:
+    job = data.read_pydantic(JobRun, "jobs/simple")
+    cancel = data.read_pydantic(JobCancel, "cancel/simple")
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
 
-    status: JobStatus | None = await query_service.start_query(job)
-    assert status == started_status
-    assert_approximately_now(status.timestamp)
-    assert status.query_info
-    start_time = status.query_info.start_time
+    start_status = await query_service.start_query(job)
+    data.assert_job_status_matches(start_status, "status/simple-started")
+    assert_approximately_now(start_status.timestamp)
+    assert start_status.query_info
+    start_time = start_status.query_info.start_time
     assert_approximately_now(start_time)
 
     assert await state_store.get_active_queries() == {"1"}
 
     now = datetime.now(tz=UTC)
-    status = await query_service.cancel_query(cancel)
+    cancel_status = await query_service.cancel_query(cancel)
+    assert cancel_status
     finish = datetime.now(tz=UTC)
-    assert status == canceled_status
-    assert_approximately_now(status.timestamp)
-    assert status.query_info
-    assert status.query_info.start_time == start_time
-    assert status.query_info.end_time
-    assert status.query_info.end_time >= now
+    data.assert_job_status_matches(cancel_status, "status/simple-aborted")
+    assert_approximately_now(cancel_status.timestamp)
+    assert cancel_status.query_info
+    assert cancel_status.query_info.start_time == start_time
+    assert cancel_status.query_info.end_time
+    assert cancel_status.query_info.end_time >= now
 
     # Check that the correct metrics event was sent.
     assert isinstance(factory.events.query_abort, MockEventPublisher)
@@ -267,20 +269,24 @@ async def test_cancel(factory: Factory) -> None:
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_cancel_completed(
-    factory: Factory, mock_qserv: MockQserv, mock_slack: MockSlackWebhook
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    mock_slack: MockSlackWebhook,
 ) -> None:
     query_service = factory.create_query_service()
-    job = read_test_job_run("simple")
-    expected_status = read_test_job_status("simple-started")
-    cancel = read_test_job_cancel("simple")
+    job = data.read_pydantic(JobRun, "jobs/simple")
+    cancel = data.read_pydantic(JobCancel, "cancel/simple")
 
     # Start the query.
     start_time = datetime.now(tz=UTC).replace(microsecond=0)
-    assert await query_service.start_query(job) == expected_status
+    start_status = await query_service.start_query(job)
+    data.assert_job_status_matches(start_status, "status/simple-started")
 
     # Mark the query complete in the mock behind the back of the bridge.
-    qserv_status = read_test_qserv_status(
-        "simple-completed",
+    qserv_status = data.read_qserv_status(
+        "qserv/simple-completed",
         query_begin=start_time,
         last_update=datetime.now(tz=UTC).replace(microsecond=0),
     )
@@ -298,16 +304,18 @@ async def test_cancel_completed(
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_maxrec(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_maxrec(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     query_service = factory.create_query_service()
-    job = read_test_job_run("data-maxrec")
-    expected_status = read_test_job_status("data-maxrec-completed")
+    job = data.read_pydantic(JobRun, "jobs/data-maxrec")
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-maxrec-completed",
     )
 
 
@@ -315,17 +323,19 @@ async def test_maxrec(factory: Factory, mock_qserv: MockQserv) -> None:
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_maxrec_zero(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_maxrec_zero(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     """Test a query with MAXREC set to zero."""
     query_service = factory.create_query_service()
-    job = read_test_job_run("data-zero")
-    expected_status = read_test_job_status("data-zero-completed")
+    job = data.read_pydantic(JobRun, "jobs/data-zero")
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-zero-completed",
     )
 
 
@@ -334,31 +344,35 @@ async def test_maxrec_zero(factory: Factory, mock_qserv: MockQserv) -> None:
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_no_api_version(
-    factory: Factory, mock_qserv: MockQserv, monkeypatch: pytest.MonkeyPatch
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test disabling sending the API version in Qserv requests."""
     monkeypatch.setattr(config, "qserv_rest_send_api_version", False)
     query_service = factory.create_query_service()
-    job = read_test_job_run("data")
-    expected_status = read_test_job_status("data-completed")
+    job = data.read_pydantic(JobRun, "jobs/data")
     state_store = factory.create_query_state_store()
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-completed",
     )
 
     # Also test starting a job with table upload, since that tests an
     # additional API endpoint.
-    job = read_test_job_run("upload")
-    expected_status = read_test_job_status("upload-started")
-    expected_status.execution_id = "2"
+    job = data.read_pydantic(JobRun, "jobs/upload")
 
     mock_qserv.set_immediate_success(None)
     status = await query_service.start_query(job)
-    assert status == expected_status
+    data.assert_job_status_matches(
+        status, "status/upload-started", execution_id="2"
+    )
     assert_approximately_now(status.timestamp)
     assert status.query_info
     assert_approximately_now(status.query_info.start_time)
@@ -371,32 +385,35 @@ async def test_no_api_version(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_auth(
-    factory: Factory, mock_qserv: MockQserv, monkeypatch: pytest.MonkeyPatch
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test authenticating to the Qserv REST API."""
     monkeypatch.setattr(config, "qserv_rest_username", "someuser")
     monkeypatch.setattr(config, "qserv_rest_password", SecretStr("password"))
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("data")
-    expected_status = read_test_job_status("data-completed")
+    job = data.read_pydantic(JobRun, "jobs/data")
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=expected_status,
+        status="status/data-completed",
     )
 
     # Also test starting a job with table upload, since that tests an
     # additional API endpoint.
-    job = read_test_job_run("upload")
-    expected_status = read_test_job_status("upload-started")
-    expected_status.execution_id = "2"
-
+    job = data.read_pydantic(JobRun, "jobs/upload")
     mock_qserv.set_immediate_success(None)
     status = await query_service.start_query(job)
-    assert status == expected_status
+    data.assert_job_status_matches(
+        status, "status/upload-started", execution_id="2"
+    )
     assert_approximately_now(status.timestamp)
     assert status.query_info
     assert_approximately_now(status.query_info.start_time)
@@ -408,20 +425,21 @@ async def test_auth(
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
+async def test_upload(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
     """Test temporary table upload."""
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("upload")
-    completed_status = read_test_job_status("upload-completed")
-    started_status = read_test_job_status("upload-started")
+    job = data.read_pydantic(JobRun, "jobs/upload")
 
     start = datetime.now(tz=UTC)
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=completed_status,
+        status="status/upload-completed",
     )
     finish = datetime.now(tz=UTC)
     assert mock_qserv.get_uploaded_table() is None
@@ -443,7 +461,7 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
         "rows": 2,
         "qserv_size": 250,
         "qserv_rate": ANY,
-        "encoded_size": len(read_test_data("results/data.binary2")),
+        "encoded_size": len(data.read_text("results/data.binary2")),
         "result_size": ANY,
         "rate": ANY,
         "result_rate": ANY,
@@ -467,8 +485,9 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
     # (not yet deleted) since the query is still running.
     mock_qserv.set_immediate_success(None)
     status = await query_service.start_query(job)
-    started_status.execution_id = "2"
-    assert status == started_status
+    data.assert_job_status_matches(
+        status, "status/upload-started", execution_id="2"
+    )
     assert mock_qserv.get_uploaded_table() == job.upload_tables[0].table_name
     assert mock_qserv.get_uploaded_database() == job.upload_tables[0].database
 
@@ -478,18 +497,18 @@ async def test_upload(factory: Factory, mock_qserv: MockQserv) -> None:
 
 @pytest.mark.asyncio
 async def test_upload_director(
-    factory: Factory, mock_qserv: MockQserv
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
 ) -> None:
     """Test upload of a spatially-partitioned (director) table."""
     query_service = factory.create_query_service()
-    job = read_test_job_run("upload-director")
-    completed_status = read_test_job_status("upload-completed")
+    job = data.read_pydantic(JobRun, "jobs/upload-director")
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=completed_status,
+        status="status/upload-completed",
     )
     assert mock_qserv.get_uploaded_table() is None
     assert mock_qserv.get_uploaded_database() is None
@@ -497,18 +516,18 @@ async def test_upload_director(
 
 @pytest.mark.asyncio
 async def test_upload_dependent(
-    factory: Factory, mock_qserv: MockQserv
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
 ) -> None:
     """Test upload of a dependent (FK-partitioned) table."""
     query_service = factory.create_query_service()
-    job = read_test_job_run("upload-dependent")
-    completed_status = read_test_job_status("upload-completed")
+    job = data.read_pydantic(JobRun, "jobs/upload-dependent")
 
     await assert_query_successful(
+        data=data,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
-        expected_status=completed_status,
+        status="status/upload-completed",
     )
     assert mock_qserv.get_uploaded_table() is None
     assert mock_qserv.get_uploaded_database() is None
@@ -516,12 +535,12 @@ async def test_upload_dependent(
 
 @pytest.mark.asyncio
 async def test_upload_submit_failure(
-    factory: Factory, mock_qserv: MockQserv
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
 ) -> None:
     """Test that a rejected submission cleans up any uploaded tables."""
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    job = read_test_job_run("upload")
+    job = data.read_pydantic(JobRun, "jobs/upload")
 
     mock_qserv.set_submit_response(
         Response(200, json={"success": 0, "error": "Some error"})

--- a/tests/storage/qserv_test.py
+++ b/tests/storage/qserv_test.py
@@ -3,10 +3,11 @@
 import pytest
 
 from qservkafka.factory import Factory
+from qservkafka.models.kafka import JobRun
 from qservkafka.models.progress import ChunkProgress
 from qservkafka.models.query import AsyncQueryPhase, ProcessStatus
 
-from ..support.data import read_test_job_run, read_test_job_status
+from ..support.data import QservKafkaData
 from ..support.qserv import MockQserv
 
 
@@ -15,18 +16,17 @@ from ..support.qserv import MockQserv
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
 async def test_list_running_queries(
-    factory: Factory, mock_qserv: MockQserv
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
 ) -> None:
     qserv = factory.create_backend_client()
     query_service = factory.create_query_service()
-    job = read_test_job_run("simple")
-    expected_status = read_test_job_status("simple-started")
+    job = data.read_pydantic(JobRun, "jobs/simple")
 
     processes = await qserv.list_running_queries()
     assert processes == {}
 
     status = await query_service.start_query(job)
-    assert status == expected_status
+    data.assert_job_status_matches(status, "status/simple-started")
     processes = await qserv.list_running_queries()
     qserv_status = mock_qserv.get_status(1)
     expected_process_status = ProcessStatus(

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -1,197 +1,82 @@
 """Utilities for reading test data."""
 
-import json
 from datetime import datetime
-from pathlib import Path
-from typing import Any
 
-from qservkafka.models.kafka import JobCancel, JobRun, JobStatus
+from safir.testing.data import Data
+
+from qservkafka.models.kafka import JobStatus
 from qservkafka.models.qserv import QservAsyncStatusData
 
-from ..support.constants import ANY_DATETIME, ANY_OPTIONAL_DATETIME
-
-__all__ = [
-    "read_test_data",
-    "read_test_job_run",
-    "read_test_job_status",
-    "read_test_job_status_json",
-    "read_test_json",
-    "read_test_qserv_status",
-]
+__all__ = ["QservKafkaData"]
 
 
-def read_test_data(filename: str) -> str:
-    """Read an input data file and return its contents.
+class QservKafkaData(Data):
+    """Manage test data for the qserv-kafka bridge."""
 
-    Parameters
-    ----------
-    config
-        Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
-    filename
-        File to read.
+    def assert_job_status_matches(
+        self, seen: JobStatus, path: str, *, execution_id: str | None = None
+    ) -> None:
+        """Raise an assertion if the job status model doesn't match.
 
-    Returns
-    -------
-    str
-        Contents of the file.
-    """
-    return (Path(__file__).parent.parent / "data" / filename).read_text()
+        Parameters
+        ----------
+        seen
+            Expected job status.
+        path
+            Path relative to :file:`tests/data` of the expected output. A
+            ``.json`` extension will be added automatically.
+        execution_id
+            If provided, override the expected execution ID with the given
+            value. If this is specified, do not overwrite the expected data
+            even if data updating is enabled.
 
+        Raises
+        ------
+        AssertionError
+            Raised if the data doesn't match.
+        """
+        if self._update and execution_id is None:
+            self.write_pydantic(seen, path, exclude_defaults=True)
+        seen_json = seen.model_dump(mode="json", exclude_defaults=True)
+        expected_json = self.read_json(path)
+        if execution_id is not None:
+            expected_json["executionID"] = execution_id
+        assert seen_json == expected_json
 
-def read_test_json(filename: str) -> Any:
-    """Read test data as JSON and return its decoded form.
+    def read_qserv_status(
+        self,
+        path: str,
+        *,
+        query_id: int | None = None,
+        query_begin: datetime | None = None,
+        last_update: datetime | None = None,
+    ) -> QservAsyncStatusData:
+        """Read the result of q Qserv query status API call.
 
-    Any ``<ANY>`` strings in the JSON are converted to `unittest.mock.ANY`
-    after being read in.
+        Parameters
+        ----------
+        path
+            Path relative to :file:`tests/data` of the expected output. A
+            ``.json`` extension will be added automatically.
+        query_id
+            Override the ``execution_id`` field.
+        query_begin
+            Override the ``query_begin`` timestamp. Any microsecond value
+            will be dropped since Qserv doesn't include microseconds.
+        last_update
+            Override the ``last_update`` timestamp. Any microsecond value
+            will be dropped since Qserv doesn't include microseconds.
 
-    Parameters
-    ----------
-    filename
-        File to read relative to the test data directory, without any
-        ``.json`` suffix. Must be in JSON format.
-    mock
-
-    Returns
-    -------
-    typing.Any
-        Parsed contents of the file.
-    """
-    path = Path(__file__).parent.parent / "data" / (filename + ".json")
-    with path.open("r") as f:
-        return json.load(f)
-
-
-def read_test_job_cancel(filename: str) -> JobCancel:
-    """Read test data parsed as a Kafka message to cancel a query.
-
-    Parameters
-    ----------
-    filename
-        File to read relative to the test cancel directory, without the
-        ``.json`` suffix.
-
-    Returns
-    -------
-    JobCancel
-        Parsed contents of the file.
-    """
-    return JobCancel.model_validate(read_test_json(f"cancel/{filename}"))
-
-
-def read_test_job_run(filename: str) -> JobRun:
-    """Read test data parsed as a Kafka message to run a query.
-
-    Parameters
-    ----------
-    filename
-        File to read relative to the test jobs directory, without the
-        ``.json`` suffix.
-
-    Returns
-    -------
-    JobRun
-        Parsed contents of the file.
-    """
-    return JobRun.model_validate(read_test_json(f"jobs/{filename}"))
-
-
-def read_test_job_run_json(filename: str) -> JobRun:
-    """Read test data parsed as JSON to run a query.
-
-    Parameters
-    ----------
-    filename
-        File to read relative to the test jobs directory, without the
-        ``.json`` suffix.
-
-    Returns
-    -------
-    JobRun
-        Parsed contents of the file.
-    """
-    return read_test_json(f"jobs/{filename}")
-
-
-def read_test_job_status(filename: str) -> JobStatus:
-    """Read test data parsed as a Kafka job status message.
-
-    Parameters
-    ----------
-    filename
-        File to read relative to the test status directory, without the
-        ``.json`` suffix.
-
-    Returns
-    -------
-    JobStatus
-        Parsed contents of the file.
-    """
-    result = JobStatus.model_validate(read_test_json(f"status/{filename}"))
-    result.timestamp = ANY_DATETIME
-    if result.query_info:
-        result.query_info.start_time = ANY_DATETIME
-        if result.query_info.end_time:
-            result.query_info.end_time = ANY_OPTIONAL_DATETIME
-    return result
-
-
-def read_test_job_status_json(filename: str) -> dict[str, Any]:
-    """Read JSON for a Kafka job status message.
-
-    Parameters
-    ----------
-    filename
-        File to read relative to the test status directory, without the
-        ``.json`` suffix.
-
-    Returns
-    -------
-    JobStatus
-        Parsed contents of the file.
-    """
-    model = JobStatus.model_validate(read_test_json(f"status/{filename}"))
-    result = model.model_dump(mode="json")
-    result["timestamp"] = ANY_DATETIME
-    if result.get("queryInfo"):
-        result["queryInfo"]["startTime"] = ANY_DATETIME
-        if result["queryInfo"].get("endTime"):
-            result["queryInfo"]["endTime"] = ANY_DATETIME
-    return result
-
-
-def read_test_qserv_status(
-    filename: str,
-    *,
-    query_id: int | None = None,
-    query_begin: datetime | None = None,
-    last_update: datetime | None = None,
-) -> QservAsyncStatusData:
-    """Read the result of q Qserv query status API call.
-
-    Parameters
-    ----------
-    filename
-        File to read relative to the test :file:`qserv` directory, without the
-        ``.json`` suffix.
-    query_id
-        Override the ``execution_id`` number.
-    query_begin
-        Override the ``query_begin`` timestamp.
-    last_update
-        Override the ``last_update`` timestamp.
-
-    Returns
-    -------
-    QservAsyncStatusData
-        Parsed contents of the file.
-    """
-    model_data = read_test_json(f"qserv/{filename}")
-    model = QservAsyncStatusData.model_validate(model_data)
-    if query_id:
-        model.query_id = query_id
-    if query_begin:
-        model.query_begin = query_begin.replace(microsecond=0)
-    if last_update:
-        model.last_update = last_update.replace(microsecond=0)
-    return model
+        Returns
+        -------
+        QservAsyncStatusData
+            Parsed contents of the file.
+        """
+        model = self.read_pydantic(QservAsyncStatusData, path)
+        if query_id is not None:
+            model.query_id = query_id
+        if query_begin:
+            model.query_begin = query_begin.replace(microsecond=0)
+        if last_update:
+            model.last_update = last_update.replace(microsecond=0)
+        return model

--- a/tests/support/kafka.py
+++ b/tests/support/kafka.py
@@ -6,21 +6,14 @@ from datetime import timedelta
 
 from aiokafka import AIOKafkaConsumer
 from faststream.kafka import KafkaBroker
+from pydantic import ValidationError
 
 from qservkafka.config import config
 from qservkafka.factory import Factory
 from qservkafka.models.kafka import JobRun, JobStatus
 
-from ..support.data import (
-    read_test_job_run,
-    read_test_job_run_json,
-    read_test_job_status,
-    read_test_job_status_json,
-)
-from ..support.datetime import (
-    assert_approximately_now,
-    milliseconds_to_timestamp,
-)
+from ..support.data import QservKafkaData
+from ..support.datetime import assert_approximately_now
 
 __all__ = [
     "start_query",
@@ -29,11 +22,15 @@ __all__ = [
 ]
 
 
-async def start_query(kafka_broker: KafkaBroker, job: str) -> JobRun:
+async def start_query(
+    data: QservKafkaData, kafka_broker: KafkaBroker, job: str
+) -> JobRun:
     """Send the Kafka message to start a query.
 
     Parameters
     ----------
+    data
+        Test data.
     kafka_broker
         Kafka broker to use to send the message.
     job
@@ -44,13 +41,13 @@ async def start_query(kafka_broker: KafkaBroker, job: str) -> JobRun:
     JobRun
         Parsed version of the Kafka message.
     """
-    job_model = read_test_job_run(job)
-    job_json = read_test_job_run_json(job)
+    job_json = data.read_json(f"jobs/{job}")
     await kafka_broker.publish(job_json, config.job_run_topic)
-    return job_model
+    return JobRun.model_validate(job_json)
 
 
 async def wait_for_status(
+    data: QservKafkaData,
     kafka_status_consumer: AIOKafkaConsumer,
     status: str,
     *,
@@ -60,10 +57,12 @@ async def wait_for_status(
 
     Parameters
     ----------
+    data
+        Test data.
     kafka_status_consumer
         Consumer for the Kafka status topic.
     status
-        Name to the Kafka status message to expect.
+        Name of the Kafka status message to expect.
     execution_id
         If set, expect this execution ID instead of the one in the loaded JSON
         file.
@@ -73,36 +72,24 @@ async def wait_for_status(
     JobStatus
         Parsed Kafka status message.
     """
-    expected = read_test_job_status_json(status)
-    status_model = read_test_job_status(status)
-    if execution_id is not None:
-        expected["executionID"] = execution_id
-        status_model.execution_id = execution_id
-
     # Get the status message from Kafka and do the equality check
     raw_message = await kafka_status_consumer.getone()
     try:
         message = json.loads(raw_message.value.decode())
-    except json.JSONDecodeError as e:
+        status_model = JobStatus.model_validate(message)
+    except (json.JSONDecodeError, ValidationError) as e:
         msg = f"cannot decode message {raw_message.value.decode()}"
         raise AssertionError(msg) from e
-    assert message == expected
+    data.assert_job_status_matches(
+        status_model, f"status/{status}", execution_id=execution_id
+    )
 
-    # Check the timestamps and update the model to match the received message.
-    timestamp = milliseconds_to_timestamp(message["timestamp"])
-    assert_approximately_now(timestamp)
-    status_model.timestamp = timestamp
-    if message.get("queryInfo"):
-        start_time_milli = message["queryInfo"]["startTime"]
-        start_time = milliseconds_to_timestamp(start_time_milli)
-        assert_approximately_now(start_time)
-        assert status_model.query_info
-        status_model.query_info.start_time = start_time
-        if message["queryInfo"].get("endTime"):
-            end_time_milli = message["queryInfo"]["endTime"]
-            end_time = milliseconds_to_timestamp(end_time_milli)
-            assert_approximately_now(end_time)
-            status_model.query_info.end_time = end_time
+    # Check the timestamps.
+    assert_approximately_now(status_model.timestamp)
+    if status_model.query_info:
+        assert_approximately_now(status_model.query_info.start_time)
+        if status_model.query_info.end_time:
+            assert_approximately_now(status_model.query_info.end_time)
     return status_model
 
 

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -34,12 +34,7 @@ from qservkafka.models.qserv import (
 from qservkafka.storage import qserv
 from qservkafka.storage.qserv import API_VERSION
 
-from .data import (
-    read_test_data,
-    read_test_job_run,
-    read_test_json,
-    read_test_qserv_status,
-)
+from .data import QservKafkaData
 
 __all__ = ["MockQserv", "register_mock_qserv"]
 
@@ -98,6 +93,8 @@ class MockQserv:
 
     Parameters
     ----------
+    data
+        Test data management class.
     sessionmaker
         Factory for database sessions.
     respx_mock
@@ -119,6 +116,7 @@ class MockQserv:
 
     def __init__(
         self,
+        data: QservKafkaData,
         sessionmaker: async_sessionmaker,
         respx_mock: respx.Router,
         *,
@@ -126,6 +124,7 @@ class MockQserv:
     ) -> None:
         self.flaky = flaky
 
+        self._data = data
         self._sessionmaker = sessionmaker
         self._respx_mock = respx_mock
 
@@ -455,7 +454,7 @@ class MockQserv:
         url = str(job.result_url)
         self._respx_mock.put(url).mock(side_effect=self.upload)
         assert not self._results_stored
-        data = read_test_json("results/data")
+        data = self._data.read_json("results/data")
         async with self._sessionmaker() as session:
             async with session.begin():
                 for row in data:
@@ -491,16 +490,16 @@ class MockQserv:
         self._next_query_id += 1
         now = datetime.now(tz=UTC).replace(microsecond=0)
         if self._immediate_success:
-            self._queries[query_id] = read_test_qserv_status(
-                "data-completed",
+            self._queries[query_id] = self._data.read_qserv_status(
+                "qserv/data-completed",
                 query_id=query_id,
                 query_begin=now,
                 last_update=now,
             )
             await self.store_results(self._immediate_success)
         else:
-            status = read_test_qserv_status(
-                "data-executing",
+            status = self._data.read_qserv_status(
+                "qserv/data-executing",
                 query_id=query_id,
                 query_begin=now,
                 last_update=now,
@@ -563,13 +562,13 @@ class MockQserv:
         assert self._expected_job
         header = self._expected_job.result_format.envelope.header
         if self._expected_job.maxrec == 1:
-            expected = read_test_data("results/data-maxrec.binary2")
+            expected = self._data.read_text("results/data-maxrec.binary2")
             footer = self._expected_job.result_format.envelope.footer_overflow
         elif self._expected_job.maxrec == 0:
             expected = "\n"
             footer = self._expected_job.result_format.envelope.footer_overflow
         else:
-            expected = read_test_data("results/data.binary2")
+            expected = self._data.read_text("results/data.binary2")
             footer = self._expected_job.result_format.envelope.footer
         assert request.content.decode() == header + expected + footer
         if self._upload_delay:
@@ -611,9 +610,12 @@ class MockQserv:
         body.close()
 
         # Check the request is correct.
-        job = self._immediate_success or read_test_job_run("upload")
-        upload_table = job.upload_tables[0]
-        expected: dict[str, str] = {
+        if self._immediate_success:
+            expected_job = self._immediate_success
+        else:
+            expected_job = self._data.read_pydantic(JobRun, "jobs/upload")
+        upload_table = expected_job.upload_tables[0]
+        expected = {
             "database": upload_table.database,
             "table": upload_table.table,
             "fields_terminated_by": ",",
@@ -675,22 +677,25 @@ class MockQserv:
 
 @asynccontextmanager
 async def register_mock_qserv(
+    data: QservKafkaData,
     respx_mock: respx.Router,
-    base_url: str,
     engine: AsyncEngine,
     *,
+    base_url: str,
     flaky: bool = False,
 ) -> AsyncGenerator[MockQserv]:
     """Mock out the Qserv REST API.
 
     Parameters
     ----------
+    data
+        Test data management class.
     respx_mock
         Mock router.
-    base_url
-        Base URL on which the mock API should appear to listen.
     engine
         Database engine.
+    base_url
+        Base URL on which the mock API should appear to listen.
     flaky
         Whether to simulate a flaky Qserv by returning SQL or HTTP errors
         every other request.
@@ -701,7 +706,7 @@ async def register_mock_qserv(
         Mock Qserv API object.
     """
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
-    mock = MockQserv(sessionmaker, respx_mock, flaky=flaky)
+    mock = MockQserv(data, sessionmaker, respx_mock, flaky=flaky)
     base = re.escape(str(base_url).rstrip("/"))
     regex = rf"{base}/query-async"
     respx_mock.post(url__regex=regex).mock(side_effect=mock.submit)
@@ -716,7 +721,7 @@ async def register_mock_qserv(
     regex = rf"{base}/query-async/status/(?P<query_id>[0-9]+)"
     respx_mock.get(url__regex=regex).mock(side_effect=mock.status)
 
-    upload_job = read_test_job_run("upload")
+    upload_job = data.read_pydantic(JobRun, "jobs/upload")
     for upload_table in upload_job.upload_tables:
         url = upload_table.source_url
         respx_mock.get(url).mock(side_effect=mock.get_upload_source)


### PR DESCRIPTION
Use the safir.testing.data helpers instead of home-grown helper functions and update the saved test data to use wildcards. Ensure all test data is in the canonical serialization format, rather than using the Python attribute names for some files and not others.