### PR TITLE
DM-55463: Move metrics events into data files

### DIFF
--- a/tests/data/events/abort.json
+++ b/tests/data/events/abort.json
@@ -1,0 +1,5 @@
+{
+  "elapsed": "<ANY>",
+  "job_id": "uws123",
+  "username": "username"
+}

--- a/tests/data/events/error.json
+++ b/tests/data/events/error.json
@@ -1,0 +1,6 @@
+{
+  "elapsed": "<ANY>",
+  "error": "backend_error",
+  "job_id": "uws123",
+  "username": "username"
+}

--- a/tests/data/events/success-kafka.json
+++ b/tests/data/events/success-kafka.json
@@ -1,0 +1,19 @@
+{
+  "delete_elapsed": "<ANY>",
+  "elapsed": "<ANY>",
+  "encoded_size": 244,
+  "immediate": false,
+  "job_id": "uws123",
+  "kafka_elapsed": "<ANY>",
+  "qserv_elapsed": "PT0S",
+  "qserv_rate": null,
+  "qserv_size": 250,
+  "rate": "<ANY>",
+  "result_elapsed": "<ANY>",
+  "result_rate": "<ANY>",
+  "result_size": 436,
+  "rows": 2,
+  "submit_elapsed": "<ANY>",
+  "upload_tables": 0,
+  "username": "username"
+}

--- a/tests/data/events/success-no-delete.json
+++ b/tests/data/events/success-no-delete.json
@@ -1,0 +1,19 @@
+{
+  "delete_elapsed": null,
+  "elapsed": "<ANY>",
+  "encoded_size": 244,
+  "immediate": true,
+  "job_id": "uws123",
+  "kafka_elapsed": "<ANY>",
+  "qserv_elapsed": "PT0S",
+  "qserv_rate": null,
+  "qserv_size": 250,
+  "rate": "<ANY>",
+  "result_elapsed": "<ANY>",
+  "result_rate": "<ANY>",
+  "result_size": 436,
+  "rows": 2,
+  "submit_elapsed": "<ANY>",
+  "upload_tables": 0,
+  "username": "username"
+}

--- a/tests/data/events/success-upload.json
+++ b/tests/data/events/success-upload.json
@@ -1,0 +1,19 @@
+{
+  "delete_elapsed": "<ANY>",
+  "elapsed": "<ANY>",
+  "encoded_size": 244,
+  "immediate": true,
+  "job_id": "uws123",
+  "kafka_elapsed": "<ANY>",
+  "qserv_elapsed": "PT0S",
+  "qserv_rate": null,
+  "qserv_size": 250,
+  "rate": "<ANY>",
+  "result_elapsed": "<ANY>",
+  "result_rate": "<ANY>",
+  "result_size": 434,
+  "rows": 2,
+  "submit_elapsed": "<ANY>",
+  "upload_tables": 1,
+  "username": "username"
+}

--- a/tests/data/events/success.json
+++ b/tests/data/events/success.json
@@ -1,0 +1,19 @@
+{
+  "delete_elapsed": "<ANY>",
+  "elapsed": "<ANY>",
+  "encoded_size": 244,
+  "immediate": true,
+  "job_id": "uws123",
+  "kafka_elapsed": "<ANY>",
+  "qserv_elapsed": "PT0S",
+  "qserv_rate": null,
+  "qserv_size": 250,
+  "rate": "<ANY>",
+  "result_elapsed": "<ANY>",
+  "result_rate": "<ANY>",
+  "result_size": 436,
+  "rows": 2,
+  "submit_elapsed": "<ANY>",
+  "upload_tables": 0,
+  "username": "username"
+}

--- a/tests/data/events/upload.json
+++ b/tests/data/events/upload.json
@@ -1,0 +1,6 @@
+{
+  "elapsed": "<ANY>",
+  "job_id": "uws123",
+  "size": 8,
+  "username": "username"
+}

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -2,7 +2,6 @@
 
 import json
 from datetime import UTC, datetime
-from unittest.mock import ANY
 
 import pytest
 from aiokafka import AIOKafkaConsumer
@@ -85,25 +84,8 @@ async def test_success(
     assert isinstance(factory.events.qserv_success, MockEventPublisher)
     events = factory.events.qserv_success.published
     assert len(events) == 1
-    assert events[0].model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "elapsed": ANY,
-        "kafka_elapsed": ANY,
-        "qserv_elapsed": ANY,
-        "result_elapsed": ANY,
-        "submit_elapsed": ANY,
-        "delete_elapsed": ANY,
-        "rows": 2,
-        "qserv_size": qserv_status.collected_bytes,
-        "qserv_rate": ANY,
-        "encoded_size": ANY,
-        "result_size": ANY,
-        "rate": ANY,
-        "result_rate": ANY,
-        "upload_tables": 0,
-        "immediate": False,
-    }
+    data.assert_pydantic_matches(events[0], "events/success-kafka")
+    assert events[0].qserv_size == qserv_status.collected_bytes
     assert events[0].kafka_elapsed <= start_time - start
 
 

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -1,7 +1,7 @@
 """Tests for errors during query creation or completion."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 import pytest
 from httpx import Response
@@ -168,14 +168,8 @@ async def test_status_errors(
     assert isinstance(factory.events.query_failure, MockEventPublisher)
     events = factory.events.query_failure.published
     assert len(events) == 1
-    failure_event = events[0]
-    assert failure_event.model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "error": "backend_error",
-        "elapsed": ANY,
-    }
-    assert timedelta(seconds=0) < failure_event.elapsed <= (now - start)
+    data.assert_pydantic_matches(events[0], "events/error")
+    assert timedelta(seconds=0) < events[0].elapsed <= (now - start)
 
     assert await state_store.get_active_queries() == set()
 

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -1,7 +1,6 @@
 """Tests for creating new queries."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import ANY
 
 import pytest
 from httpx import Response
@@ -105,31 +104,7 @@ async def test_immediate(
     events = factory.events.qserv_success.published
     assert len(events) == 1
     event = events[0]
-    assert event.model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "elapsed": ANY,
-        "kafka_elapsed": ANY,
-        "qserv_elapsed": ANY,
-        "result_elapsed": ANY,
-        "submit_elapsed": ANY,
-        "delete_elapsed": ANY,
-        "rows": 2,
-        "qserv_size": 250,
-        "qserv_rate": None,
-        "encoded_size": len(data.read_text("results/data.binary2")),
-        "result_size": (
-            len(data.read_text("results/data.binary2"))
-            + len(job.result_format.envelope.header)
-            + len(job.result_format.envelope.footer)
-        ),
-        "rate": event.encoded_size / event.elapsed.total_seconds(),
-        "result_rate": (
-            event.encoded_size / event.result_elapsed.total_seconds()
-        ),
-        "upload_tables": 0,
-        "immediate": True,
-    }
+    data.assert_pydantic_matches(event, "events/success")
 
     # These time fields should include the fake Kafka delay of 10s.
     for field in ("elapsed", "kafka_elapsed"):
@@ -145,6 +120,12 @@ async def test_immediate(
         "delete_elapsed",
     ):
         assert timedelta(seconds=0) <= getattr(event, field) <= elapsed
+
+    # Check the calculated rates.
+    assert event.rate == event.encoded_size / event.elapsed.total_seconds()
+    assert event.result_rate == (
+        event.encoded_size / event.result_elapsed.total_seconds()
+    )
 
     # It should be possible to immediately run the same query again. This
     # tests that the results were deleted from the database, and thus can be
@@ -201,25 +182,7 @@ async def test_no_delete(
     assert isinstance(factory.events.qserv_success, MockEventPublisher)
     events = factory.events.qserv_success.published
     assert len(events) == 1
-    assert events[0].model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "elapsed": ANY,
-        "kafka_elapsed": ANY,
-        "qserv_elapsed": ANY,
-        "result_elapsed": ANY,
-        "submit_elapsed": ANY,
-        "delete_elapsed": None,
-        "rows": 2,
-        "qserv_size": 250,
-        "qserv_rate": ANY,
-        "encoded_size": len(data.read_text("results/data.binary2")),
-        "result_size": ANY,
-        "rate": ANY,
-        "result_rate": ANY,
-        "upload_tables": 0,
-        "immediate": True,
-    }
+    data.assert_pydantic_matches(events[0], "events/success-no-delete")
 
 
 @pytest.mark.asyncio
@@ -256,11 +219,7 @@ async def test_cancel(data: QservKafkaData, factory: Factory) -> None:
     assert isinstance(factory.events.query_abort, MockEventPublisher)
     events = factory.events.query_abort.published
     assert len(events) == 1
-    assert events[0].model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "elapsed": ANY,
-    }
+    data.assert_pydantic_matches(events[0], "events/abort")
     assert timedelta(seconds=0) < events[0].elapsed <= (finish - start_time)
 
 
@@ -449,36 +408,12 @@ async def test_upload(
     assert isinstance(factory.events.qserv_success, MockEventPublisher)
     events = factory.events.qserv_success.published
     assert len(events) == 1
-    assert events[0].model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "elapsed": ANY,
-        "kafka_elapsed": ANY,
-        "qserv_elapsed": ANY,
-        "result_elapsed": ANY,
-        "submit_elapsed": ANY,
-        "delete_elapsed": ANY,
-        "rows": 2,
-        "qserv_size": 250,
-        "qserv_rate": ANY,
-        "encoded_size": len(data.read_text("results/data.binary2")),
-        "result_size": ANY,
-        "rate": ANY,
-        "result_rate": ANY,
-        "upload_tables": 1,
-        "immediate": True,
-    }
+    data.assert_pydantic_matches(events[0], "events/success-upload")
     assert isinstance(factory.events.temporary_table, MockEventPublisher)
     events = factory.events.temporary_table.published
     assert len(events) == 1
-    upload_event = events[0]
-    assert upload_event.model_dump(mode="json") == {
-        "job_id": job.job_id,
-        "username": job.owner,
-        "size": len(mock_qserv._UPLOAD_CSV),
-        "elapsed": ANY,
-    }
-    assert timedelta(seconds=0) < upload_event.elapsed <= (finish - start)
+    data.assert_pydantic_matches(events[0], "events/upload")
+    assert timedelta(seconds=0) < events[0].elapsed <= (finish - start)
 
     # Start another upload query, but this time don't let it complete
     # immediately. In this case, the uploaded table should still be present


### PR DESCRIPTION
Stop hard-coding expected metrics events in tests and move them into data files with separate assertions for values that have to be calculated in the test.