### PR TITLE
DM-55463: Add a wrapper around Kafka test management

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ from qservkafka.factory import Factory, ProcessContext
 from qservkafka.main import create_app
 
 from .support.data import QservKafkaData
+from .support.kafka import KafkaTestManager
 from .support.qserv import MockQserv, register_mock_qserv
 
 
@@ -171,6 +172,15 @@ def kafka_connection_settings(
 def kafka_docker_network() -> Iterator[Network]:
     with Network() as network:
         yield network
+
+
+@pytest.fixture
+def kafka_manager(
+    data: QservKafkaData,
+    kafka_broker: KafkaBroker,
+    kafka_status_consumer: AIOKafkaConsumer,
+) -> KafkaTestManager:
+    return KafkaTestManager(data, kafka_broker, kafka_status_consumer)
 
 
 @pytest_asyncio.fixture

--- a/tests/kafka/leak_test.py
+++ b/tests/kafka/leak_test.py
@@ -11,11 +11,9 @@ from datetime import UTC, datetime
 
 import pytest
 import respx
-from aiokafka import AIOKafkaConsumer
 from arq import Worker
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
-from faststream.kafka import KafkaBroker
 from safir.logging import LogLevel
 from safir.metrics import metrics_configuration_factory
 
@@ -23,9 +21,9 @@ from qservkafka.config import config
 from qservkafka.dependencies.context import context_dependency
 from qservkafka.factory import Factory
 
-from ..support.arq import create_arq_worker
+from ..support.arq import create_arq_worker, wait_for_dispatch
 from ..support.data import QservKafkaData
-from ..support.kafka import start_query, wait_for_dispatch, wait_for_status
+from ..support.kafka import KafkaTestManager
 from ..support.qserv import MockQserv
 
 
@@ -56,19 +54,15 @@ async def run_job(
     *,
     data: QservKafkaData,
     factory: Factory,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     arq_worker: Worker,
     execution_id: int,
 ) -> None:
     """Run a single job end-to-end."""
-    job = await start_query(data, kafka_broker, "data")
-    status = await wait_for_status(
-        data,
-        kafka_status_consumer,
-        "data-started",
-        execution_id=str(execution_id),
+    job = await kafka_manager.start_query("jobs/data")
+    status = await kafka_manager.wait_for_status(
+        "status/data-started", execution_id=str(execution_id)
     )
     assert status.query_info
     start_time = status.query_info.start_time
@@ -82,11 +76,8 @@ async def run_job(
     await mock_qserv.update_status(execution_id, qserv_status)
     await wait_for_dispatch(factory, execution_id)
     assert await arq_worker.run_check() == execution_id
-    await wait_for_status(
-        data,
-        kafka_status_consumer,
-        "data-completed",
-        execution_id=str(execution_id),
+    await kafka_manager.wait_for_status(
+        "status/data-completed", execution_id=str(execution_id)
     )
 
 
@@ -96,8 +87,7 @@ async def test_leak(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     respx_mock: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
@@ -112,8 +102,7 @@ async def test_leak(
         await run_job(
             data=data,
             factory=factory,
-            kafka_broker=kafka_broker,
-            kafka_status_consumer=kafka_status_consumer,
+            kafka_manager=kafka_manager,
             mock_qserv=mock_qserv,
             arq_worker=arq_worker,
             execution_id=1,
@@ -129,8 +118,7 @@ async def test_leak(
             await run_job(
                 data=data,
                 factory=factory,
-                kafka_broker=kafka_broker,
-                kafka_status_consumer=kafka_status_consumer,
+                kafka_manager=kafka_manager,
                 mock_qserv=mock_qserv,
                 arq_worker=arq_worker,
                 execution_id=i,

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -4,7 +4,6 @@ import json
 from datetime import UTC, datetime
 
 import pytest
-from aiokafka import AIOKafkaConsumer
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from faststream.kafka import KafkaBroker
@@ -24,9 +23,9 @@ from qservkafka.dependencies.context import context_dependency
 from qservkafka.models.kafka import JobRun
 from qservkafka.models.state import RunningQuery
 
-from ..support.arq import create_arq_worker
+from ..support.arq import create_arq_worker, wait_for_dispatch
 from ..support.data import QservKafkaData
-from ..support.kafka import start_query, wait_for_dispatch, wait_for_status
+from ..support.kafka import KafkaTestManager
 from ..support.qserv import MockQserv
 
 
@@ -39,8 +38,7 @@ async def test_success(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     redis: RedisContainer,
 ) -> None:
@@ -49,10 +47,8 @@ async def test_success(
         arq_worker = create_arq_worker(factory._context)
 
         start = datetime.now(tz=UTC)
-        job = await start_query(data, kafka_broker, "data")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "data-started"
-        )
+        job = await kafka_manager.start_query("jobs/data")
+        status = await kafka_manager.wait_for_status("status/data-started")
         assert status.query_info
         start_time = status.query_info.start_time
 
@@ -63,14 +59,11 @@ async def test_success(
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
         await mock_qserv.update_status(1, qserv_status)
-
         await wait_for_dispatch(factory, 1)
 
         # Run the background task queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(
-            data, kafka_status_consumer, "data-completed"
-        )
+        status = await kafka_manager.wait_for_status("status/data-completed")
         assert status.query_info
         assert status.query_info.start_time == start_time
         assert status.query_info.end_time
@@ -95,8 +88,7 @@ async def test_failure(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     redis: RedisContainer,
 ) -> None:
@@ -104,10 +96,8 @@ async def test_failure(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        await start_query(data, kafka_broker, "simple")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-started"
-        )
+        await kafka_manager.start_query("jobs/simple")
+        status = await kafka_manager.wait_for_status("status/simple-started")
         assert status.query_info
         start_time = status.query_info.start_time
 
@@ -116,9 +106,7 @@ async def test_failure(
             "qserv/simple-partial", query_begin=start_time, last_update=now
         )
         await mock_qserv.update_status(1, qserv_status)
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-partial"
-        )
+        status = await kafka_manager.wait_for_status("status/simple-partial")
         assert status.timestamp == now
         assert status.query_info
         assert status.query_info.start_time == start_time
@@ -132,9 +120,7 @@ async def test_failure(
 
         # Run the background tsk queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-failed"
-        )
+        status = await kafka_manager.wait_for_status("status/simple-failed")
         assert status.timestamp == now
         assert status.query_info
         assert status.query_info.start_time == start_time
@@ -152,8 +138,7 @@ async def test_too_large(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     redis: RedisContainer,
 ) -> None:
@@ -161,10 +146,8 @@ async def test_too_large(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        await start_query(data, kafka_broker, "simple")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-started"
-        )
+        await kafka_manager.start_query("jobs/simple")
+        status = await kafka_manager.wait_for_status("status/simple-started")
         assert status.query_info
         start_time = status.query_info.start_time
 
@@ -177,9 +160,7 @@ async def test_too_large(
 
         # Run the background tsk queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-large"
-        )
+        status = await kafka_manager.wait_for_status("status/simple-large")
         assert status.timestamp == now
         assert status.query_info
         assert status.query_info.start_time == start_time
@@ -197,8 +178,7 @@ async def test_qserv_error(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     redis: RedisContainer,
 ) -> None:
@@ -211,14 +191,12 @@ async def test_qserv_error(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        await start_query(data, kafka_broker, "simple")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-started"
-        )
+        await kafka_manager.start_query("jobs/simple")
+        status = await kafka_manager.wait_for_status("status/simple-started")
         assert status.query_info
         start_time = status.query_info.start_time
 
-        error_json = {"success": 0, "error": "Some error"}
+        error_json = data.read_json("qserv/error")
         mock_qserv.set_status_response(Response(200, json=error_json))
         qserv_status = data.read_qserv_status(
             "qserv/simple-completed",
@@ -230,9 +208,7 @@ async def test_qserv_error(
 
         # Run the background tsk queue.
         assert await arq_worker.run_check() == 1
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-error"
-        )
+        status = await kafka_manager.wait_for_status("status/simple-error")
 
     # Ensure all query state has been deleted.
     redis_client = redis.get_client()
@@ -245,16 +221,15 @@ async def test_missing_executing(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     redis: RedisContainer,
 ) -> None:
     """Test queries that are not in the process list but still executing."""
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
-        await start_query(data, kafka_broker, "data")
-        await wait_for_status(data, kafka_status_consumer, "data-started")
+        await kafka_manager.start_query("jobs/data")
+        await kafka_manager.wait_for_status("status/data-started")
 
         # Remove the query from the running query list. It should be
         # dispatched to the result worker.
@@ -265,7 +240,7 @@ async def test_missing_executing(
     # status update we already sent (since nothing has changed).
     arq_worker = create_arq_worker()
     assert await arq_worker.run_check() == 1
-    await wait_for_status(data, kafka_status_consumer, "data-started")
+    await kafka_manager.wait_for_status("status/data-started")
 
     # The query should still be active and should no longer be marked as
     # dispatched, so it will be checked again the next time through the
@@ -283,15 +258,13 @@ async def test_cancel(
     *,
     data: QservKafkaData,
     app: FastAPI,
+    kafka_manager: KafkaTestManager,
     kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
     redis: RedisContainer,
 ) -> None:
     async with LifespanManager(app):
-        await start_query(data, kafka_broker, "simple")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-started"
-        )
+        await kafka_manager.start_query("jobs/simple")
+        status = await kafka_manager.wait_for_status("status/simple-started")
         assert status.query_info
         start_time = status.query_info.start_time
 
@@ -299,9 +272,7 @@ async def test_cancel(
         cancel = data.read_json("cancel/simple")
         await kafka_broker.publish(cancel, config.job_cancel_topic)
 
-        status = await wait_for_status(
-            data, kafka_status_consumer, "simple-aborted"
-        )
+        status = await kafka_manager.wait_for_status("status/simple-aborted")
         assert status.query_info
         assert status.query_info.start_time == start_time
         assert status.query_info.end_time
@@ -318,20 +289,17 @@ async def test_upload(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_qserv: MockQserv,
     redis: RedisContainer,
 ) -> None:
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
 
-        job = await start_query(data, kafka_broker, "upload")
+        job = await kafka_manager.start_query("jobs/upload")
         table_name = job.upload_tables[0].table_name
         database_name = job.upload_tables[0].database
-        status = await wait_for_status(
-            data, kafka_status_consumer, "upload-started"
-        )
+        status = await kafka_manager.wait_for_status("status/upload-started")
         assert status.query_info
         start_time = status.query_info.start_time
         assert mock_qserv.get_uploaded_table() == table_name
@@ -353,7 +321,7 @@ async def test_upload(
     # Run the backend worker.
     arq_worker = create_arq_worker()
     assert await arq_worker.run_check() == 1
-    await wait_for_status(data, kafka_status_consumer, "upload-failed")
+    await kafka_manager.wait_for_status("status/upload-failed")
 
     # Now that results have been processed, the table should be deleted.
     assert mock_qserv.get_uploaded_database() is None
@@ -370,8 +338,7 @@ async def test_quota(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_gafaelfawr: MockGafaelfawr,
     mock_qserv: MockQserv,
     redis: RedisContainer,
@@ -389,21 +356,19 @@ async def test_quota(
         arq_worker = create_arq_worker(factory._context)
 
         # Start a couple of queries.
-        await start_query(data, kafka_broker, "data")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "data-started"
-        )
+        await kafka_manager.start_query("jobs/data")
+        status = await kafka_manager.wait_for_status("status/data-started")
         assert status.query_info
         start_time = status.query_info.start_time
-        job = await start_query(data, kafka_broker, "data")
-        await wait_for_status(
-            data, kafka_status_consumer, "data-started", execution_id="2"
+        job = await kafka_manager.start_query("jobs/data")
+        await kafka_manager.wait_for_status(
+            "status/data-started", execution_id="2"
         )
 
         # This should have exhausted the user's quota, and starting a third
         # job should be rejected with an error.
-        await start_query(data, kafka_broker, "data")
-        await wait_for_status(data, kafka_status_consumer, "data-overquota")
+        await kafka_manager.start_query("jobs/data")
+        await kafka_manager.wait_for_status("status/data-overquota")
 
         # Make sure that we decremented the counter of running queries again
         # when rejecting that job.
@@ -421,12 +386,12 @@ async def test_quota(
 
         # Run the background task queue.
         assert await arq_worker.run_check() == 1
-        await wait_for_status(data, kafka_status_consumer, "data-completed")
+        await kafka_manager.wait_for_status("status/data-completed")
 
         # Now, it should be possible to start a new query.
-        await start_query(data, kafka_broker, "data")
-        await wait_for_status(
-            data, kafka_status_consumer, "data-started", execution_id="3"
+        await kafka_manager.start_query("jobs/data")
+        await kafka_manager.wait_for_status(
+            "status/data-started", execution_id="3"
         )
         assert redis_client.get(f"rate:{job.owner}") == b"2"
 
@@ -437,8 +402,7 @@ async def test_wrong_schema(
     *,
     data: QservKafkaData,
     app: FastAPI,
-    kafka_broker: KafkaBroker,
-    kafka_status_consumer: AIOKafkaConsumer,
+    kafka_manager: KafkaTestManager,
     mock_slack: MockSlackWebhook,
     mock_qserv: MockQserv,
     redis: RedisContainer,
@@ -447,10 +411,8 @@ async def test_wrong_schema(
         factory = context_dependency.create_factory()
         arq_worker = create_arq_worker(factory._context)
 
-        job = await start_query(data, kafka_broker, "data-wrong-schema")
-        status = await wait_for_status(
-            data, kafka_status_consumer, "data-started"
-        )
+        job = await kafka_manager.start_query("jobs/data-wrong-schema")
+        status = await kafka_manager.wait_for_status("status/data-started")
         assert status.query_info
         start_time = status.query_info.start_time
 
@@ -461,12 +423,11 @@ async def test_wrong_schema(
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
         await mock_qserv.update_status(1, qserv_status)
-
         await wait_for_dispatch(factory, 1)
 
         # Run the background task queue.
         assert await arq_worker.run_check() == 1
-        await wait_for_status(data, kafka_status_consumer, "data-wrong-schema")
+        await kafka_manager.wait_for_status("status/data-wrong-schema")
 
     # Ensure all query state has been deleted.
     redis_client = redis.get_client()

--- a/tests/support/arq.py
+++ b/tests/support/arq.py
@@ -1,14 +1,16 @@
 """Test support functions for arq queuing."""
 
+import asyncio
 import inspect
+from datetime import timedelta
 
 from arq import Worker
 
 from qservkafka.config import config
-from qservkafka.factory import ProcessContext
+from qservkafka.factory import Factory, ProcessContext
 from qservkafka.workers.main import WorkerSettings
 
-__all__ = ["create_arq_worker"]
+__all__ = ["create_arq_worker", "wait_for_dispatch"]
 
 
 def create_arq_worker(context: ProcessContext | None = None) -> Worker:
@@ -34,3 +36,40 @@ def create_arq_worker(context: ProcessContext | None = None) -> Worker:
         ctx=ctx,
         **{k: v for k, v in vars(WorkerSettings).items() if k in worker_args},
     )
+
+
+async def wait_for_dispatch(
+    factory: Factory,
+    query_id: int,
+    *,
+    timeout: timedelta = timedelta(seconds=1),
+) -> None:
+    """Wait for a job to be queued for the result worker.
+
+    Parameters
+    ----------
+    factory
+        Component factory to use.
+    query_id
+        Qserv query ID.
+    timeout
+        How long to wait for the dispatch before giving up.
+
+    Raises
+    ------
+    TimeoutError
+        Raised if it takes more than the timeout interval for the job to be
+        dispatched to the backend worker.
+    """
+    state_store = factory.create_query_state_store()
+
+    # Use polling of Redis, since subscribing to key updates in Redis is
+    # complicated enough that I don't feel like writing all that code.
+    poll_delay = config.backend_poll_interval.total_seconds() / 2
+    async with asyncio.timeout(timeout.total_seconds()):
+        while True:
+            query = await state_store.get_query(str(query_id))
+            assert query
+            if query.result_queued:
+                return
+            await asyncio.sleep(poll_delay)

--- a/tests/support/kafka.py
+++ b/tests/support/kafka.py
@@ -1,130 +1,102 @@
 """Helper functions for running queries end-to-end with Kafka."""
 
-import asyncio
 import json
-from datetime import timedelta
 
 from aiokafka import AIOKafkaConsumer
 from faststream.kafka import KafkaBroker
 from pydantic import ValidationError
 
 from qservkafka.config import config
-from qservkafka.factory import Factory
 from qservkafka.models.kafka import JobRun, JobStatus
 
 from ..support.data import QservKafkaData
 from ..support.datetime import assert_approximately_now
 
-__all__ = [
-    "start_query",
-    "wait_for_dispatch",
-    "wait_for_status",
-]
+__all__ = ["KafkaTestManager"]
 
 
-async def start_query(
-    data: QservKafkaData, kafka_broker: KafkaBroker, job: str
-) -> JobRun:
-    """Send the Kafka message to start a query.
+class KafkaTestManager:
+    """Manage the steps of a test that uses a real Kafka service.
+
+    This class encapsulates the various objects used to talk to the Kafka
+    service to set up a test and provides a simple API to tests to perform the
+    Kafka portions of a query.
 
     Parameters
     ----------
     data
-        Test data.
+        Test data management class.
     kafka_broker
         Kafka broker to use to send the message.
-    job
-        Name of the Kafka message to send.
-
-    Returns
-    -------
-    JobRun
-        Parsed version of the Kafka message.
-    """
-    job_json = data.read_json(f"jobs/{job}")
-    await kafka_broker.publish(job_json, config.job_run_topic)
-    return JobRun.model_validate(job_json)
-
-
-async def wait_for_status(
-    data: QservKafkaData,
-    kafka_status_consumer: AIOKafkaConsumer,
-    status: str,
-    *,
-    execution_id: str | None = None,
-) -> JobStatus:
-    """Wait for a Kafka status message and check it.
-
-    Parameters
-    ----------
-    data
-        Test data.
     kafka_status_consumer
         Consumer for the Kafka status topic.
-    status
-        Name of the Kafka status message to expect.
-    execution_id
-        If set, expect this execution ID instead of the one in the loaded JSON
-        file.
-
-    Returns
-    -------
-    JobStatus
-        Parsed Kafka status message.
     """
-    # Get the status message from Kafka and do the equality check
-    raw_message = await kafka_status_consumer.getone()
-    try:
-        message = json.loads(raw_message.value.decode())
-        status_model = JobStatus.model_validate(message)
-    except (json.JSONDecodeError, ValidationError) as e:
-        msg = f"cannot decode message {raw_message.value.decode()}"
-        raise AssertionError(msg) from e
-    data.assert_job_status_matches(
-        status_model, f"status/{status}", execution_id=execution_id
-    )
 
-    # Check the timestamps.
-    assert_approximately_now(status_model.timestamp)
-    if status_model.query_info:
-        assert_approximately_now(status_model.query_info.start_time)
-        if status_model.query_info.end_time:
-            assert_approximately_now(status_model.query_info.end_time)
-    return status_model
+    def __init__(
+        self,
+        data: QservKafkaData,
+        kafka_broker: KafkaBroker,
+        kafka_status_consumer: AIOKafkaConsumer,
+    ) -> None:
+        self._data = data
+        self._broker = kafka_broker
+        self._consumer = kafka_status_consumer
 
+    async def start_query(self, path: str) -> JobRun:
+        """Send the Kafka message to start a query.
 
-async def wait_for_dispatch(
-    factory: Factory,
-    query_id: int,
-    *,
-    timeout: timedelta = timedelta(seconds=1),
-) -> None:
-    """Wait for a job to be queued for the result worker.
+        Parameters
+        ----------
+        job
+            Path to the Kafka job message to send. This is a relative path to
+            :file:`tests/data` without any ``.json`` extension.
 
-    Parameters
-    ----------
-    factory
-        Component factory to use.
-    query_id
-        Qserv query ID.
-    timeout
-        How long to wait for the dispatch before giving up.
+        Returns
+        -------
+        JobRun
+            Parsed version of the Kafka message.
+        """
+        job_json = self._data.read_json(path)
+        await self._broker.publish(job_json, config.job_run_topic)
+        return JobRun.model_validate(job_json)
 
-    Raises
-    ------
-    TimeoutError
-        Raised if it takes more than the timeout interval for the job to be
-        dispatched to the backend worker.
-    """
-    state_store = factory.create_query_state_store()
+    async def wait_for_status(
+        self,
+        path: str,
+        *,
+        execution_id: str | None = None,
+    ) -> JobStatus:
+        """Wait for a Kafka status message and check it.
 
-    # Use polling of Redis, since subscribing to key updates in Redis is
-    # complicated enough that I don't feel like writing all that code.
-    poll_delay = config.backend_poll_interval.total_seconds() / 2
-    async with asyncio.timeout(timeout.total_seconds()):
-        while True:
-            query = await state_store.get_query(str(query_id))
-            assert query
-            if query.result_queued:
-                return
-            await asyncio.sleep(poll_delay)
+        Parameters
+        ----------
+        status
+            Path to the Kafka status message to expect. This is a relative
+            path to :file:`tests/data` without any ``.json`` extension.
+        execution_id
+            If set, expect this execution ID instead of the one in the loaded
+            JSON file.
+
+        Returns
+        -------
+        JobStatus
+            Parsed Kafka status message.
+        """
+        raw_message = await self._consumer.getone()
+        try:
+            message = json.loads(raw_message.value.decode())
+            status = JobStatus.model_validate(message)
+        except (json.JSONDecodeError, ValidationError) as e:
+            msg = f"cannot decode message {raw_message.value.decode()}"
+            raise AssertionError(msg) from e
+        self._data.assert_job_status_matches(
+            status, path, execution_id=execution_id
+        )
+
+        # Check the timestamps.
+        assert_approximately_now(status.timestamp)
+        if status.query_info:
+            assert_approximately_now(status.query_info.start_time)
+            if status.query_info.end_time:
+                assert_approximately_now(status.query_info.end_time)
+        return status


### PR DESCRIPTION
Add a class that encapsulates the Kafka API objects and makes it a bit less verbose to run the stages of a Kafka test. Move the test helper function `wait_for_dispatch` into tests.support.arq, since it doesn't really have anything to do with Kafka.