### PR TITLE
DM-55679: Dispatch query upload and result processing for immediate results to arq workers

### DIFF
--- a/changelog.d/20260803_215912_steliosvoutsinas_DM_55679.md
+++ b/changelog.d/20260803_215912_steliosvoutsinas_DM_55679.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Jobs with table uploads and queries that complete before their first status check are now dispatched to arq workers, so a slow upload can no longer delay unrelated querie behind them.

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -381,6 +381,34 @@ class Config(BaseSettings):
         description="Used to determine which TAP quota to apply",
     )
 
+    upload_queue: str = Field(
+        "arq:upload",
+        title="arq queue for jobs with table uploads",
+        description=(
+            "Separate arq queue for jobs with table uploads, listened to by"
+            " UploadWorkerSettings instead of the default result-processing"
+            " worker pool"
+        ),
+    )
+
+    upload_worker_max_jobs: int = Field(
+        10,
+        title="Concurrent upload worker jobs per pod",
+        description=(
+            "Table uploads are I/O-bound so we default to a higher "
+            " default than the result-processing worker pool"
+        ),
+    )
+
+    upload_worker_timeout: HumanTimedelta = Field(
+        timedelta(minutes=15),
+        title="Timeout for starting a query with table uploads",
+        description=(
+            "Maximum time allowed to upload tables and submit the query to"
+            " the backend"
+        ),
+    )
+
     @property
     def arq_redis_settings(self) -> RedisSettings:
         """Redis settings for arq."""

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -160,8 +160,8 @@ class QuerySuccessEvent(BaseQueryEvent):
         False,
         title="Query finished immediately",
         description=(
-            "Whether the query finished so quickly that it was processed"
-            " entirely by the frontend"
+            "Whether the query had already completed before its"
+            " status was first checked"
         ),
     )
 

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -72,6 +72,9 @@ class ProcessContext:
     kafka_broker: KafkaBroker
     """Kafka broker to use for publishing messages from background jobs."""
 
+    arq_queue: ArqQueue
+    """Queue to which to dispatch work to arq workers."""
+
     event_manager: EventManager
     """Manager for publishing metrics events."""
 
@@ -150,6 +153,8 @@ class ProcessContext:
             logger=logger,
         )
 
+        arq_queue = await cls._create_arq_queue()
+
         return cls(
             http_client=http_client,
             discovery_client=discovery_client,
@@ -161,6 +166,7 @@ class ProcessContext:
             gafaelfawr=gafaelfawr,
             events=events,
             redis=redis_client,
+            arq_queue=arq_queue,
         )
 
     @classmethod
@@ -250,6 +256,17 @@ class ProcessContext:
                 return None, None
 
     @classmethod
+    async def _create_arq_queue(cls) -> ArqQueue:
+        """Create the queue used to dispatch work to arq workers."""
+        if config.arq_mode == ArqMode.production:
+            settings = config.arq_redis_settings
+            return await RedisArqQueue.initialize(
+                settings, default_queue_name=config.arq_queue
+            )
+        else:
+            return MockArqQueue()
+
+    @classmethod
     def _create_slack_client(
         cls, logger: BoundLogger
     ) -> SlackWebhookClient | None:
@@ -273,6 +290,7 @@ class ProcessContext:
         """
         await self.event_manager.aclose()
         await self.kafka_broker.stop()
+        await self.arq_queue.aclose()
         await self.redis.aclose()
         if self.engine is not None:
             await self.engine.dispose()
@@ -385,17 +403,10 @@ class Factory:
         QueryMonitor
             New service to monitor query status.
         """
-        if config.arq_mode == ArqMode.production:
-            settings = config.arq_redis_settings
-            arq_queue: ArqQueue = await RedisArqQueue.initialize(
-                settings, default_queue_name=config.arq_queue
-            )
-        else:
-            arq_queue = MockArqQueue()
         return QueryMonitor(
             result_processor=self.create_result_processor(),
             backend=self.create_backend_client(),
-            arq_queue=arq_queue,
+            arq_queue=self._context.arq_queue,
             state_store=self.create_query_state_store(),
             rate_limit_store=self.create_rate_limit_store(),
             events=self._context.events,
@@ -404,11 +415,6 @@ class Factory:
 
     def create_query_service(self) -> QueryService:
         """Create a new service for starting queries.
-
-        Parameters
-        ----------
-        arq_queue
-            arq queue to which to dispatch result handling jobs.
 
         Returns
         -------
@@ -421,6 +427,7 @@ class Factory:
             result_processor=self.create_result_processor(),
             rate_limit_store=self.create_rate_limit_store(),
             gafaelfawr_storage=self.gafaelfawr,
+            arq_queue=self._context.arq_queue,
             events=self._context.events,
             slack_client=self._context.slack_client,
             logger=self._logger,
@@ -454,6 +461,7 @@ class Factory:
             ),
             kafka_broker=self._context.kafka_broker,
             rate_limit_store=self.create_rate_limit_store(),
+            arq_queue=self._context.arq_queue,
             events=self._context.events,
             slack_client=self._context.slack_client,
             logger=self._logger,

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -30,6 +30,10 @@ class Query(BaseModel):
 
     job: Annotated[JobRun, Field(title="Full job request")]
 
+    immediate: Annotated[
+        bool, Field(title="Whether query completed before first status check")
+    ] = False
+
     def to_logging_context(self) -> dict[str, str | float]:
         """Convert to variables for a structlog logging context."""
         result: dict[str, str | float] = {
@@ -99,6 +103,7 @@ class RunningQuery(Query):
             start=query.start,
             created=query.created,
             job=query.job,
+            immediate=query.immediate,
             status=status,
             result_queued=False,
         )

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -2,11 +2,13 @@
 
 from datetime import UTC, datetime
 
+from safir.arq import ArqQueue
 from safir.sentry import report_exception
 from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
+from ..config import config
 from ..events import Events, TemporaryTableUploadEvent
 from ..exceptions import (
     BackendApiError,
@@ -48,6 +50,8 @@ class QueryService:
         Storage for rate limiting.
     gafaelfawr_storage
         Storage for quota information.
+    arq_queue
+        Shared client used to dispatch jobs to arq workers.
     events
         Metrics events publishers.
     slack_client
@@ -64,6 +68,7 @@ class QueryService:
         result_processor: ResultProcessor,
         rate_limit_store: RateLimitStore,
         gafaelfawr_storage: GafaelfawrStorage,
+        arq_queue: ArqQueue,
         events: Events,
         slack_client: SlackWebhookClient | None,
         logger: BoundLogger,
@@ -73,6 +78,7 @@ class QueryService:
         self._results = result_processor
         self._rate_store = rate_limit_store
         self._gafaelfawr = gafaelfawr_storage
+        self._arq_queue = arq_queue
         self._events = events
         self._slack_client = slack_client
         self._logger = logger
@@ -146,7 +152,9 @@ class QueryService:
         """Handle an incoming request to run a query.
 
         Start the query if possible and publish the status of the query as a
-        Kafka message.
+        Kafka message. Jobs with table uploads are dispatched to an arq
+        worker instead, since an upload can take a long time and would
+        otherwise block consumption of the job-run topic.
 
         Parameters
         ----------
@@ -155,6 +163,14 @@ class QueryService:
         kafka_start
             Time at which the Kafka message for the job was queued.
         """
+        if job.upload_tables:
+            await self._arq_queue.enqueue(
+                "handle_upload_job",
+                job,
+                kafka_start,
+                _queue_name=config.upload_queue,
+            )
+            return
         status = await self.start_query(job, kafka_start)
         await self._results.publish_status(status)
 

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import override
 
 from faststream.kafka import KafkaBroker
+from safir.arq import ArqQueue
 from safir.sentry import report_exception
 from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
@@ -67,6 +68,8 @@ class ResultProcessor(ABC):
         Broker to use to publish status messages.
     rate_limit_store
         Storage for rate limiting.
+    arq_queue
+        Shared client used to dispatch jobs to arq workers.
     events
         Metrics events publishers.
     slack_client
@@ -83,6 +86,7 @@ class ResultProcessor(ABC):
         votable_writer: VOTableWriter,
         kafka_broker: KafkaBroker,
         rate_limit_store: RateLimitStore,
+        arq_queue: ArqQueue,
         events: Events,
         slack_client: SlackWebhookClient | None,
         logger: BoundLogger,
@@ -92,6 +96,7 @@ class ResultProcessor(ABC):
         self._votable = votable_writer
         self._kafka = kafka_broker
         self._rate_store = rate_limit_store
+        self._arq = arq_queue
         self._events = events
         self._slack_client = slack_client
         self._logger = logger
@@ -160,6 +165,7 @@ class ResultProcessor(ABC):
             await self._delete_query_data(query, logger)
             return update
         full_query = RunningQuery.from_query(query, status)
+        logger = self._logger.bind(**full_query.to_logging_context())
 
         # Based on the status, process the results.
         match status.status:
@@ -171,10 +177,20 @@ class ResultProcessor(ABC):
                 else:
                     await self._state.update_status(query.query_id, status)
                 return self.build_executing_status(full_query)
-            case AsyncQueryPhase.COMPLETED:
-                result = await self._build_completed_status(
-                    full_query, initial=initial
+            case AsyncQueryPhase.COMPLETED if initial:
+                # The query was already completed on the first check.
+                # Dispatch to the worker pool and report the job as
+                # still executing.
+                full_query.result_queued = True
+                full_query.immediate = True
+                await self._state.store_query(full_query)
+                await self._arq.enqueue(
+                    "handle_finished_query", query.query_id
                 )
+                logger.info("Dispatched immediately completed query to worker")
+                return self.build_executing_status(full_query)
+            case AsyncQueryPhase.COMPLETED:
+                result = await self._build_completed_status(full_query)
             case AsyncQueryPhase.FAILED:
                 result = await self._build_failed_status(full_query)
 
@@ -208,7 +224,6 @@ class ResultProcessor(ABC):
         backend_elapsed: timedelta,
         backend_rate: float | None,
         delete_elapsed: timedelta | None,
-        initial: bool,
     ) -> QuerySuccessEvent:
         """Publish backend-specific success event.
 
@@ -226,8 +241,6 @@ class ResultProcessor(ABC):
             Backend processing rate (bytes/sec).
         delete_elapsed
             Time spent deleting results.
-        initial
-            Whether this was immediate completion.
 
         Returns
         -------
@@ -269,12 +282,7 @@ class ResultProcessor(ABC):
             metadata=query.job.to_job_metadata(),
         )
 
-    async def _build_completed_status(
-        self,
-        query: RunningQuery,
-        *,
-        initial: bool = False,
-    ) -> JobStatus:
+    async def _build_completed_status(self, query: RunningQuery) -> JobStatus:
         """Retrieve results and construct status for a completed job.
 
         This method is responsible for retrieving the results from the backend,
@@ -285,9 +293,6 @@ class ResultProcessor(ABC):
         ----------
         query
             Metadata about the query.
-        initial
-            Whether this is the initial invocation, immediately after creating
-            the job.
 
         Returns
         -------
@@ -333,7 +338,6 @@ class ResultProcessor(ABC):
             backend_elapsed=backend_elapsed,
             backend_rate=backend_rate,
             delete_elapsed=delete_elapsed,
-            initial=initial,
         )
         logger.info(
             "Job complete and results uploaded", **event.to_logging_context()
@@ -642,7 +646,6 @@ class QservResultProcessor(ResultProcessor):
         backend_elapsed: timedelta,
         backend_rate: float | None,
         delete_elapsed: timedelta | None,
-        initial: bool,
     ) -> QservSuccessEvent:
         event = QservSuccessEvent(
             job_id=query.job.job_id,
@@ -661,7 +664,7 @@ class QservResultProcessor(ResultProcessor):
             qserv_rate=backend_rate,
             result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
             upload_tables=len(query.job.upload_tables),
-            immediate=initial,
+            immediate=query.immediate,
         )
         await self._events.qserv_success.publish(event)
         return event
@@ -688,7 +691,6 @@ class BigQueryResultProcessor(ResultProcessor):
         backend_elapsed: timedelta,
         backend_rate: float | None,
         delete_elapsed: timedelta | None,
-        initial: bool,
     ) -> BigQuerySuccessEvent:
         event = BigQuerySuccessEvent(
             job_id=query.job.job_id,
@@ -707,7 +709,7 @@ class BigQueryResultProcessor(ResultProcessor):
             rate=stats.data_bytes / elapsed.total_seconds(),
             result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
             upload_tables=len(query.job.upload_tables),
-            immediate=initial,
+            immediate=query.immediate,
         )
         await self._events.bigquery_success.publish(event)
         return event

--- a/src/qservkafka/workers/functions/upload.py
+++ b/src/qservkafka/workers/functions/upload.py
@@ -1,0 +1,30 @@
+"""arq queue worker to start queries that include table uploads."""
+
+from datetime import datetime
+from typing import Any
+
+from ...factory import Factory
+from ...models.kafka import JobRun
+
+__all__ = ["handle_upload_job"]
+
+
+async def handle_upload_job(
+    ctx: dict[Any, Any], job: JobRun, kafka_start: datetime | None
+) -> None:
+    """Start a query that includes table uploads.
+
+    Parameters
+    ----------
+    ctx
+        arq context.
+    job
+        Query job to start.
+    kafka_start
+        Time at which the Kafka message for the job was queued.
+    """
+    factory: Factory = ctx["factory"]
+    query_service = factory.create_query_service()
+    result_processor = factory.create_result_processor()
+    status = await query_service.start_query(job, kafka_start)
+    await result_processor.publish_status(status)

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -4,6 +4,8 @@ import uuid
 from collections.abc import Callable
 from typing import Any, ClassVar
 
+from arq import func
+from arq.worker import Function
 from safir.logging import configure_logging
 from safir.metrics.arq import initialize_arq_metrics, make_on_job_start
 from safir.sentry import initialize_sentry
@@ -15,6 +17,7 @@ from ..config import config
 from ..constants import ARQ_TIMEOUT_GRACE
 from ..factory import Factory, ProcessContext
 from .functions.results import handle_finished_query
+from .functions.upload import handle_upload_job
 
 
 async def startup(ctx: dict[Any, Any]) -> None:
@@ -73,7 +76,7 @@ async def shutdown(ctx: dict[Any, Any]) -> None:
 
 
 class WorkerSettings:
-    """Configuration for the arq worker."""
+    """Configuration for the arq worker that processes completed queries."""
 
     functions: ClassVar[list[Callable]] = [handle_finished_query]
     job_completion_wait = int(
@@ -85,4 +88,28 @@ class WorkerSettings:
     on_startup = startup
     on_shutdown = shutdown
     queue_name = config.arq_queue
+    redis_settings = config.arq_redis_settings
+
+
+class UploadWorkerSettings:
+    """Configuration for the arq worker that starts queries with uploads.
+
+    Runs on a separate queue from `WorkerSettings` so that a slow upload
+    can't starve result processing.
+    """
+
+    functions: ClassVar[list[Callable | Function]] = [
+        func(
+            handle_upload_job,
+            timeout=config.upload_worker_timeout + ARQ_TIMEOUT_GRACE,
+        ),
+    ]
+    job_completion_wait = int(
+        (config.upload_worker_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
+    )
+    max_jobs = config.upload_worker_max_jobs
+    on_job_start = make_on_job_start(config.upload_queue)
+    on_startup = startup
+    on_shutdown = shutdown
+    queue_name = config.upload_queue
     redis_settings = config.arq_redis_settings

--- a/tests/data/status/data-immediate-started.json
+++ b/tests/data/status/data-immediate-started.json
@@ -1,0 +1,17 @@
+{
+  "executionID": "1",
+  "jobID": "uws123",
+  "metadata": {
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "progress": {
+      "completedChunks": 10,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "EXECUTING",
+  "timestamp": "<ANY>"
+}

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -22,8 +22,13 @@ from qservkafka.config import config
 from qservkafka.dependencies.context import context_dependency
 from qservkafka.models.kafka import JobRun
 from qservkafka.models.state import RunningQuery
+from qservkafka.workers.main import UploadWorkerSettings
 
-from ..support.arq import create_arq_worker, wait_for_dispatch
+from ..support.arq import (
+    create_arq_worker,
+    run_worker_until_processed,
+    wait_for_dispatch,
+)
 from ..support.data import QservKafkaData
 from ..support.kafka import KafkaTestManager
 from ..support.qserv import MockQserv
@@ -80,6 +85,48 @@ async def test_success(
     data.assert_pydantic_matches(events[0], "events/success-kafka")
     assert events[0].qserv_size == qserv_status.collected_bytes
     assert events[0].kafka_elapsed <= start_time - start
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(40)
+async def test_immediate(
+    *,
+    data: QservKafkaData,
+    app: FastAPI,
+    kafka_manager: KafkaTestManager,
+    mock_qserv: MockQserv,
+    redis: RedisContainer,
+) -> None:
+    """Test a query that completes before its first status check."""
+    job = data.read_pydantic(JobRun, "jobs/data")
+    mock_qserv.set_immediate_success(job)
+
+    async with LifespanManager(app):
+        factory = context_dependency.create_factory()
+        arq_worker = create_arq_worker(factory._context)
+
+        await kafka_manager.start_query("jobs/data")
+        status = await kafka_manager.wait_for_status(
+            "status/data-immediate-started"
+        )
+        assert status.query_info
+        start_time = status.query_info.start_time
+
+        await wait_for_dispatch(factory, 1)
+
+        assert await arq_worker.run_check() == 1
+        status = await kafka_manager.wait_for_status("status/data-completed")
+        assert status.query_info
+        assert status.query_info.start_time == start_time
+        assert status.query_info.end_time
+        assert status.query_info.end_time >= start_time
+
+    redis_client = redis.get_client()
+    assert set(redis_client.scan_iter("query:*")) == set()
+    assert isinstance(factory.events.qserv_success, MockEventPublisher)
+    events = factory.events.qserv_success.published
+    assert len(events) == 1
+    assert events[0].immediate is True
 
 
 @pytest.mark.asyncio
@@ -295,10 +342,17 @@ async def test_upload(
 ) -> None:
     async with LifespanManager(app):
         factory = context_dependency.create_factory()
+        upload_worker = create_arq_worker(
+            factory._context, settings=UploadWorkerSettings
+        )
 
         job = await kafka_manager.start_query("jobs/upload")
         table_name = job.upload_tables[0].table_name
         database_name = job.upload_tables[0].database
+
+        # Jobs with table uploads are dispatched to a separate arq worker
+        # pool so that worker has to run before the job is actually started.
+        assert await run_worker_until_processed(upload_worker) == 1
         status = await kafka_manager.wait_for_status("status/upload-started")
         assert status.query_info
         start_time = status.query_info.start_time

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -15,6 +15,7 @@ from qservkafka.storage import qserv
 from ..support.data import QservKafkaData
 from ..support.datetime import assert_approximately_now
 from ..support.qserv import MockQserv
+from ..support.query import start_and_complete_immediate
 
 
 @pytest.mark.asyncio
@@ -147,7 +148,9 @@ async def test_sql_failure(
     mock_qserv.set_immediate_success(job)
     results_sql = "SELECT * FROM nonexistent"
     with patch.object(qserv, "_query_results_sql", return_value=results_sql):
-        status = await query_service.start_query(job)
+        status = await start_and_complete_immediate(
+            query_service, factory, job
+        )
     data.assert_job_status_matches(status, "status/error-sql")
     assert status.error
     assert "SQL query error: " in status.error.message
@@ -175,7 +178,7 @@ async def test_upload_timeout(
     mock_qserv.set_immediate_success(job)
     mock_qserv.set_upload_delay(timedelta(seconds=2))
     monkeypatch.setattr(config, "result_timeout", timedelta(seconds=1))
-    status = await query_service.start_query(job)
+    status = await start_and_complete_immediate(query_service, factory, job)
     data.assert_job_status_matches(status, "status/error-upload-timeout")
     assert_approximately_now(status.timestamp)
 

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -20,6 +20,7 @@ from qservkafka.models.kafka import JobRun
 
 from ..support.data import QservKafkaData
 from ..support.qserv import MockQserv
+from ..support.query import start_and_complete_immediate
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -61,7 +62,7 @@ async def test_success(
     mock_qserv.set_immediate_success(job)
 
     # Run one query first to set up the various internal Python caches.
-    status = await query_service.start_query(job)
+    status = await start_and_complete_immediate(query_service, factory, job)
     data.assert_job_status_matches(status, "status/data-completed")
 
     # Start tracing memory.
@@ -71,7 +72,9 @@ async def test_success(
 
     # Run 100 more tasks with memory tracing.
     for i in range(2, 102):
-        status = await query_service.start_query(job)
+        status = await start_and_complete_immediate(
+            query_service, factory, job
+        )
         data.assert_job_status_matches(
             status, "status/data-completed", execution_id=str(i)
         )

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -1,10 +1,12 @@
 """Tests for creating new queries."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import call, patch
 
 import pytest
 from httpx import Response
 from pydantic import SecretStr
+from safir.arq import RedisArqQueue
 from safir.metrics import MockEventPublisher
 from safir.testing.slack import MockSlackWebhook
 from vo_models.uws.types import ExecutionPhase
@@ -17,11 +19,13 @@ from qservkafka.services.query import QueryService
 from ..support.data import QservKafkaData
 from ..support.datetime import assert_approximately_now
 from ..support.qserv import MockQserv
+from ..support.query import start_and_complete_immediate
 
 
 async def assert_query_successful(
     *,
     data: QservKafkaData,
+    factory: Factory,
     query_service: QueryService,
     mock_qserv: MockQserv,
     job: JobRun,
@@ -34,6 +38,8 @@ async def assert_query_successful(
     ----------
     data
         Test data management.
+    factory
+        Component factory to use.
     query_service
         Query service to test.
     mock_qserv
@@ -47,7 +53,9 @@ async def assert_query_successful(
     """
     mock_qserv.set_immediate_success(job)
     kafka_timestamp = datetime.now(tz=UTC) - timedelta(seconds=10)
-    result = await query_service.start_query(job, kafka_timestamp)
+    result = await start_and_complete_immediate(
+        query_service, factory, job, kafka_start=kafka_timestamp
+    )
     data.assert_job_status_matches(result, status, execution_id=execution_id)
     assert_approximately_now(result.timestamp)
     assert result.query_info
@@ -88,6 +96,7 @@ async def test_immediate(
     start = datetime.now(tz=UTC)
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -132,6 +141,7 @@ async def test_immediate(
     # re-added.
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -152,6 +162,37 @@ async def test_immediate(
 
 
 @pytest.mark.asyncio
+async def test_immediate_dispatch(
+    data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
+) -> None:
+    """Test that a job that completed immediately is dispatched to a worker
+    and that the dispatch is not repeated on a later check.
+    """
+    query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
+    job = data.read_pydantic(JobRun, "jobs/data")
+    mock_qserv.set_immediate_success(job)
+
+    with patch.object(RedisArqQueue, "enqueue") as mock:
+        status = await query_service.start_query(job)
+        assert mock.call_args_list == [call("handle_finished_query", "1")]
+
+    assert status.status == ExecutionPhase.EXECUTING
+    assert status.execution_id == "1"
+
+    query = await state_store.get_query("1")
+    assert query
+    assert query.result_queued
+    assert query.immediate
+
+    result_processor = factory.create_result_processor()
+    with patch.object(RedisArqQueue, "enqueue") as mock:
+        result = await result_processor.build_query_status(query)
+        assert mock.call_args_list == []
+    data.assert_job_status_matches(result, "status/data-completed")
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
@@ -169,6 +210,7 @@ async def test_no_delete(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -271,6 +313,7 @@ async def test_maxrec(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -291,6 +334,7 @@ async def test_maxrec_zero(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -317,6 +361,7 @@ async def test_no_api_version(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -359,6 +404,7 @@ async def test_auth(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -395,6 +441,7 @@ async def test_upload(
     start = datetime.now(tz=UTC)
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -440,6 +487,7 @@ async def test_upload_director(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,
@@ -459,6 +507,7 @@ async def test_upload_dependent(
 
     await assert_query_successful(
         data=data,
+        factory=factory,
         query_service=query_service,
         mock_qserv=mock_qserv,
         job=job,

--- a/tests/support/arq.py
+++ b/tests/support/arq.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 from datetime import timedelta
+from typing import Any
 
 from arq import Worker
 
@@ -10,16 +11,26 @@ from qservkafka.config import config
 from qservkafka.factory import Factory, ProcessContext
 from qservkafka.workers.main import WorkerSettings
 
-__all__ = ["create_arq_worker", "wait_for_dispatch"]
+__all__ = [
+    "create_arq_worker",
+    "run_worker_until_processed",
+    "wait_for_dispatch",
+]
 
 
-def create_arq_worker(context: ProcessContext | None = None) -> Worker:
+def create_arq_worker(
+    context: ProcessContext | None = None,
+    *,
+    settings: type[Any] = WorkerSettings,
+) -> Worker:
     """Create an arq worker to run queued jobs.
 
     Parameters
     ----------
     context
         Process context to use, if given.
+    settings
+        arq worker settings class to use (default `WorkerSettings`).
 
     Returns
     -------
@@ -29,13 +40,47 @@ def create_arq_worker(context: ProcessContext | None = None) -> Worker:
     ctx = {}
     if context:
         ctx["context"] = context
-    WorkerSettings.redis_settings = config.arq_redis_settings
+    settings.redis_settings = config.arq_redis_settings
     worker_args = set(inspect.signature(Worker).parameters.keys())
     return Worker(
         burst=True,
         ctx=ctx,
-        **{k: v for k, v in vars(WorkerSettings).items() if k in worker_args},
+        **{k: v for k, v in vars(settings).items() if k in worker_args},
     )
+
+
+async def run_worker_until_processed(
+    worker: Worker,
+    *,
+    timeout: timedelta = timedelta(seconds=5),
+) -> int:
+    """Run an arq worker repeatedly until it processes a job,
+    to handle the delay during upload jobs between the Kafka consumer
+    enqueuing a job and it becoming visible to the worker.
+
+    Parameters
+    ----------
+    worker
+        Worker to run.
+    timeout
+        How long to wait for a job to appear before giving up.
+
+    Returns
+    -------
+    int
+        Number of jobs processed by the run that found at least one.
+
+    Raises
+    ------
+    TimeoutError
+        Raised if no job was processed within the timeout.
+    """
+    async with asyncio.timeout(timeout.total_seconds()):
+        while True:
+            count = await worker.run_check()
+            if count:
+                return count
+            await asyncio.sleep(0.05)
 
 
 async def wait_for_dispatch(

--- a/tests/support/query.py
+++ b/tests/support/query.py
@@ -1,0 +1,53 @@
+"""Test support for driving queriess."""
+
+from datetime import datetime
+
+from vo_models.uws.types import ExecutionPhase
+
+from qservkafka.factory import Factory
+from qservkafka.models.kafka import JobRun, JobStatus
+from qservkafka.services.query import QueryService
+
+__all__ = ["start_and_complete_immediate"]
+
+
+async def start_and_complete_immediate(
+    query_service: QueryService,
+    factory: Factory,
+    job: JobRun,
+    *,
+    kafka_start: datetime | None = None,
+) -> JobStatus:
+    """Start a query that completes immediately and wait for its result.
+
+    Queries found already complete on their first status check are
+    dispatched to the result worker, so this also simulates that worker
+    running by calling the result processor directly, just like
+    ``handle_finished_query`` does.
+
+    Parameters
+    ----------
+    query_service
+        Query service to start the job with.
+    factory
+        Component factory to use.
+    job
+        Job to start.
+    kafka_start
+        Time at which the Kafka message for the job was queued.
+
+    Returns
+    -------
+    JobStatus
+        The completed status of the job.
+    """
+    initial_status = await query_service.start_query(job, kafka_start)
+    assert initial_status.status == ExecutionPhase.EXECUTING
+    assert initial_status.execution_id
+
+    state_store = factory.create_query_state_store()
+    query = await state_store.get_query(initial_status.execution_id)
+    assert query
+
+    result_processor = factory.create_result_processor()
+    return await result_processor.build_query_status(query)


### PR DESCRIPTION
## Description

The purpose of these changes is to address the issues we've been seeing where upload jobs which take close to 1 minute to complete block other queries queued behind them in the same batch.
At the same time as part of these changes I'm also addressing a similar issue with queries that complete before their first status check (which triggers full result retrieval + encoding synchronously), which would similarly block subsequent queries.

With the changes introduced here both are now dispatched to arq workers instead of running inline.

## Notes on approach

- Result processing now always runs via `handle_finished_query`.  I think the inline path had the same problem as upload, where a query completing before its first status check triggered full result retrieval and encoding synchronously in the Kafka consumer and if this took a while it would block other queued queries so I've remove it in favor of always handling completions via the worker. 

-  I decided to introduce a separate queue since table uploads are I/O-bound, and the existing result-processing pool is capped at 2 since that one is CPU bound and sharing a pool would potentially let a few slow uploads starve result processing.

- I changed how the `immediate` metric is populated and it is now in the persisted query state instead of a local flag. 
It used to mean "processed entirely by the frontend,", but now instead it means "completed before the first status check,".

- The arq client (`ArqQueue`) is now a per-process singleton in `ProcessContext`.