### PR TITLE
DM-55734: Rewrite result timeouts to more useful exceptions

### DIFF
--- a/changelog.d/20260805_142040_rra_DM_55734.md
+++ b/changelog.d/20260805_142040_rra_DM_55734.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add more information to result retrieval and upload timeout errors when reporting them to Sentry and Slack.

--- a/src/qservkafka/exceptions.py
+++ b/src/qservkafka/exceptions.py
@@ -1,5 +1,6 @@
 """Custom exceptions for the Qserv Kafka bridge."""
 
+from datetime import timedelta
 from typing import Any, ClassVar, Self, override
 
 from safir.slack.blockkit import (
@@ -473,6 +474,25 @@ class TableUploadWebError(SlackWebException, QueryError):
     """Retrieving an uploaded table failed."""
 
     error = JobErrorCode.table_read
+
+
+class UploadTimeoutError(QueryError):
+    """Timeout retrieving and uploading the query results."""
+
+    description = "Timeout uploading results"
+    error = JobErrorCode.result_timeout
+
+    def __init__(self, elapsed: timedelta) -> None:
+        delay = elapsed.total_seconds()
+        msg = f"Timed out retrieving and uploading results after {delay:.2f}s"
+        super().__init__(msg)
+        self.elapsed = elapsed
+
+    @override
+    def to_logging_context(self) -> dict[str, Any]:
+        context = super().to_logging_context()
+        context["elapsed"] = round(self.elapsed.total_seconds(), 2)
+        return context
 
 
 class UploadWebError(SlackWebException, QueryError):

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -29,6 +29,7 @@ from ..exceptions import (
     BackendApiError,
     BackendApiTransientError,
     QueryError,
+    UploadTimeoutError,
     UploadWebError,
 )
 from ..models.kafka import (
@@ -305,7 +306,7 @@ class ResultProcessor(ABC):
         # Retrieve and upload the results.
         try:
             stats = await self._upload_results_with_retry(query, logger)
-        except (QueryError, TimeoutError) as e:
+        except QueryError as e:
             return await self._build_exception_status(query, e)
 
         # Delete the results if configured to do so.
@@ -359,9 +360,7 @@ class ResultProcessor(ABC):
         )
 
     async def _build_exception_status(
-        self,
-        query: RunningQuery,
-        exc: QueryError | TimeoutError,
+        self, query: RunningQuery, exc: QueryError
     ) -> JobStatus:
         """Construct the job status for an exception.
 
@@ -379,33 +378,18 @@ class ResultProcessor(ABC):
         JobStatus
             Status for the query.
         """
-        logger = self._logger.bind(**query.to_logging_context())
+        logger = self._logger.bind(
+            **query.to_logging_context(), **exc.to_logging_context()
+        )
         now = datetime.now(tz=UTC)
         elapsed = now - query.start
-        elapsed_seconds = elapsed.total_seconds()
 
         # Analyze the exception. _build_exception_status is only called inside
         # an exception handler, so suppress the Ruff diagnostics since Ruff
         # has no way of knowing that.
         await report_exception(exc, slack_client=self._slack_client)
-        match exc:
-            case QueryError():
-                logger.exception(  # noqa: LOG004
-                    exc.description,
-                    elapsed=elapsed_seconds,
-                    **exc.to_logging_context(),
-                )
-                error = exc.to_job_error()
-            case TimeoutError():
-                logger.exception(  # noqa: LOG004
-                    "Retrieving and uploading results timed out",
-                    elapsed=elapsed_seconds,
-                    timeout=config.result_timeout.total_seconds(),
-                )
-                error = JobError(
-                    code=JobErrorCode.result_timeout,
-                    message="Retrieving and uploading results timed out",
-                )
+        logger.exception(exc.description)  # noqa: LOG004
+        error = exc.to_job_error()
 
         # Send a metrics event for the failure.
         event = QueryFailureEvent(
@@ -561,16 +545,20 @@ class ResultProcessor(ABC):
         results = self._backend.get_query_results_gen(query.query_id)
         timeout = config.result_timeout.total_seconds()
 
-        async with asyncio.timeout(timeout):
-            size = await self._votable.store(
-                query.job.result_url,
-                query.job.result_format,
-                results,
-                maxrec=query.job.maxrec,
-            )
-            return UploadStats(
-                elapsed=datetime.now(tz=UTC) - result_start, **asdict(size)
-            )
+        try:
+            async with asyncio.timeout(timeout):
+                size = await self._votable.store(
+                    query.job.result_url,
+                    query.job.result_format,
+                    results,
+                    maxrec=query.job.maxrec,
+                )
+                return UploadStats(
+                    elapsed=datetime.now(tz=UTC) - result_start, **asdict(size)
+                )
+        except TimeoutError as e:
+            elapsed = datetime.now(tz=UTC) - result_start
+            raise UploadTimeoutError(elapsed) from e
 
     async def _upload_results_with_retry(
         self, query: RunningQuery, logger: BoundLogger

--- a/tests/data/status/error-upload-timeout.json
+++ b/tests/data/status/error-upload-timeout.json
@@ -1,7 +1,7 @@
 {
   "errorInfo": {
     "errorCode": "result_timeout",
-    "errorMessage": "Retrieving and uploading results timed out"
+    "errorMessage": "<ANY>"
   },
   "executionID": "1",
   "jobID": "uws123",

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -180,6 +180,9 @@ async def test_upload_timeout(
     monkeypatch.setattr(config, "result_timeout", timedelta(seconds=1))
     status = await start_and_complete_immediate(query_service, factory, job)
     data.assert_job_status_matches(status, "status/error-upload-timeout")
+    expected = "Timed out retrieving and uploading results after "
+    assert status.error
+    assert status.error.message.startswith(expected)
     assert_approximately_now(status.timestamp)
 
     assert await state_store.get_active_queries() == set()


### PR DESCRIPTION
Rather than raising an unenhanced timeout error and patching up the error information when assembling the Kafka error status, instead rewrite the exception into a proper internal exception. This allows the exception handling in result processing to be simplified since all of the exceptions it receives are normal, rich exceptions.