### PR TITLE
DM-55713: Cleanup now happens after publishing the status, so users don't wait on it

### DIFF
--- a/changelog.d/20260805_205307_steliosvoutsinas_DM_55713.md
+++ b/changelog.d/20260805_205307_steliosvoutsinas_DM_55713.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Publish a query's success or failure status to Kafka before cleaning up its backend resources so that users no longer have to wait for that cleanup to get their results.

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -329,6 +329,11 @@ class Factory:
         """Global shared caching Gafaelfawr client."""
         return self._context.gafaelfawr
 
+    @property
+    def slack_client(self) -> SlackWebhookClient | None:
+        """Global shared Slack client for error notifications."""
+        return self._context.slack_client
+
     async def create_background_task_manager(self) -> BackgroundTaskManager:
         """Create the background task manager to monitor Qserv jobs.
 

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -56,6 +56,15 @@ class RunningQuery(Query):
         bool, Field(title="Whether queued for result procesing")
     ]
 
+    result_published: Annotated[
+        bool, Field(title="Whether the result has been published to Kafka")
+    ] = False
+
+    needs_result_cleanup: Annotated[
+        bool,
+        Field(title="Whether the query completed and has results to delete"),
+    ] = False
+
     @model_validator(mode="before")
     @classmethod
     def _migrate_old_schema(cls, data: Any) -> Any:
@@ -106,6 +115,8 @@ class RunningQuery(Query):
             immediate=query.immediate,
             status=status,
             result_queued=False,
+            result_published=False,
+            needs_result_cleanup=False,
         )
 
     def to_job_query_info(self, *, finished: bool = False) -> JobQueryInfo:

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -86,6 +86,9 @@ class QueryService:
     async def cancel_query(self, message: JobCancel) -> JobStatus | None:
         """Cancel a running query.
 
+        Callers are responsible for any cleanup required, as well as
+        publishing resulting status.
+
         Parameters
         ----------
         message
@@ -135,7 +138,10 @@ class QueryService:
     async def handle_cancel(self, message: JobCancel) -> None:
         """Handle an incoming cancel request.
 
-        Cancel the running query if necessary and publish any status update.
+        Cancel the running query if necessary, publish any status update,
+        and then clean up backend resources for the query. Cleanup
+        is best-effort and happens after publishing so that the caller
+        is not blocked.
 
         Parameters
         ----------
@@ -143,8 +149,27 @@ class QueryService:
             Request to cancel the query.
         """
         status = await self.cancel_query(message)
-        if status:
-            await self._results.publish_status(status)
+        if not status:
+            return
+        await self._results.publish_status(status)
+        is_executing = status.status == ExecutionPhase.EXECUTING
+        if is_executing or not status.execution_id:
+            return
+        query = await self._state.get_query(status.execution_id)
+        if query:
+            needs_result_cleanup = status.status == ExecutionPhase.COMPLETED
+            try:
+                await self._results.cleanup_query(
+                    query,
+                    self._logger,
+                    needs_result_cleanup=needs_result_cleanup,
+                )
+            except Exception as e:
+                await report_exception(e, self._slack_client)
+                self._logger.exception(
+                    "Cleanup failed for cancelled query",
+                    query_id=status.execution_id,
+                )
 
     async def handle_query(
         self, job: JobRun, kafka_start: datetime | None

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -163,7 +163,12 @@ class ResultProcessor(ABC):
                 error=e.to_job_error(),
                 metadata=query.job.to_job_metadata(),
             )
-            await self._delete_query_data(query, logger)
+            if initial:
+                # We cleanup on initial here because the other paths handle
+                # cleanup themselves after publishing the status.
+                await self.cleanup_query(
+                    query, logger, needs_result_cleanup=False
+                )
             return update
         full_query = RunningQuery.from_query(query, status)
         logger = self._logger.bind(**full_query.to_logging_context())
@@ -195,10 +200,12 @@ class ResultProcessor(ABC):
             case AsyncQueryPhase.FAILED:
                 result = await self._build_failed_status(full_query)
 
-        # Query was completed, either successfully or unsuccessfully. Delete
-        # any state storage needed for it, update rate limits, and return the
-        # resulting status.
-        await self._delete_query_data(query, logger)
+        # Query was completed, either successfully or unsuccessfully. For the
+        # initial synchronous submission path (reached via failure or abort)
+        # there is no separate caller to cleanup after publishing so we
+        # do it here.
+        if initial:
+            await self.cleanup_query(query, logger, needs_result_cleanup=False)
         return result
 
     async def publish_status(self, status: JobStatus) -> None:
@@ -309,18 +316,10 @@ class ResultProcessor(ABC):
         except QueryError as e:
             return await self._build_exception_status(query, e)
 
-        # Delete the results if configured to do so.
+        # Result and database cleanup happens in cleanup_query after
+        # this status has been published to Kafka, so there is no deletion
+        # timing to report here.
         delete_elapsed = None
-        if config.qserv_delete_queries:
-            delete_start = datetime.now(tz=UTC)
-            try:
-                await self._backend.delete_result(query.query_id)
-                delete_elapsed = datetime.now(tz=UTC) - delete_start
-            except BackendApiError as e:
-                delete_elapsed = None
-                await report_exception(e, slack_client=self._slack_client)
-                logger.exception("Cannot delete results")
-            delete_elapsed = datetime.now(tz=UTC) - delete_start
 
         # Send a metrics event for the job completion and log it.
         now = datetime.now(tz=UTC)
@@ -494,13 +493,18 @@ class ResultProcessor(ABC):
                     database_name=database,
                 )
 
-    async def _delete_query_data(
-        self, query: Query, logger: BoundLogger
+    async def cleanup_query(
+        self, query: Query, logger: BoundLogger, *, needs_result_cleanup: bool
     ) -> None:
-        """Delete stored information for the query.
+        """Delete backend resources for a finished query.
 
-        Remove the query from the Kafka bridge state storage and delete
-        any uploaded temporary tables.
+        External callers (the finished-query worker, cancellation) must only
+        call this after the query's final status has already been published,
+        so that users aren't kept waiting on this cleanup. One exception is
+        `build_query_status`'s own internal use of this method for the
+        initial, synchronous submission path, which has no separate caller
+        to defer cleanup to and so calls this before  publishing as before.
+        This should be safe to call more than once.
 
         Parameters
         ----------
@@ -508,14 +512,23 @@ class ResultProcessor(ABC):
             Query metadata.
         logger
             Logger to use.
+        needs_result_cleanup
+            Whether the query completed with results in the backend that
+            need to be deleted.
         """
         logger.debug(
             "Cleaning up query data",
             upload_table_count=len(query.job.upload_tables),
         )
-        await self._state.delete_query(query.query_id)
-        await self._rate_store.end_query(query.job.owner)
+        if needs_result_cleanup and config.qserv_delete_queries:
+            try:
+                await self._backend.delete_result(query.query_id)
+            except BackendApiError as e:
+                await report_exception(e, slack_client=self._slack_client)
+                logger.exception("Cannot delete results")
         await self.delete_upload_databases(query.job, logger)
+        await self._rate_store.end_query(query.job.owner)
+        await self._state.delete_query(query.query_id)
 
     async def _upload_results(self, query: RunningQuery) -> UploadStats:
         """Retrieve and upload the results.

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -86,6 +86,28 @@ class QueryStateStore:
                 query_id, query, lifetime, exclude_defaults=True
             )
 
+    async def mark_published(
+        self, query_id: str, *, needs_result_cleanup: bool
+    ) -> None:
+        """Mark a query's result as published to Kafka.
+
+        Parameters
+        ----------
+        query_id
+            Backend query ID.
+        needs_result_cleanup
+            Whether the query completed with results that still need to be
+            deleted.
+        """
+        query = await self.get_query(query_id)
+        if query:
+            query.result_published = True
+            query.needs_result_cleanup = needs_result_cleanup
+            lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
+            await self._storage.store(
+                query_id, query, lifetime, exclude_defaults=True
+            )
+
     async def store_query(
         self, query: RunningQuery, *, result_queued: bool = False
     ) -> None:

--- a/src/qservkafka/workers/functions/results.py
+++ b/src/qservkafka/workers/functions/results.py
@@ -2,14 +2,23 @@
 
 from typing import Any
 
+from arq import Retry
+from safir.sentry import report_exception
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
+from ...config import config
 from ...factory import Factory
 
 
 async def handle_finished_query(ctx: dict[Any, Any], query_id: str) -> None:
     """Process a completed query.
+
+    Publishes the final status to Kafka as soon as the query is done,
+    before cleaning up the backend resources. This way users don't have
+    to wait for that cleanup to get their results. If cleanup fails, the job
+    retries via arq. On retry the query's state (``result_published``)
+    tells us to skip straight to cleanup.
 
     Parameters
     ----------
@@ -27,13 +36,31 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: str) -> None:
         logger.warning("Query state not found, skipping", query_id=query_id)
         return
     processor = factory.create_result_processor()
-    status = await processor.build_query_status(query)
-    if status.status == ExecutionPhase.EXECUTING:
-        logger.warning(
-            "Apparently completed job still executing",
-            job_id=query.job.job_id,
-            qserv_id=str(query.query_id),
-            username=query.job.owner,
-            status=status.model_dump(mode="json", exclude_none=True),
+
+    needs_result_cleanup = query.needs_result_cleanup
+    if not query.result_published:
+        status = await processor.build_query_status(query)
+        if status.status == ExecutionPhase.EXECUTING:
+            logger.warning(
+                "Apparently completed job still executing",
+                job_id=query.job.job_id,
+                qserv_id=str(query.query_id),
+                username=query.job.owner,
+                status=status.model_dump(mode="json", exclude_none=True),
+            )
+            await processor.publish_status(status)
+            return
+        await processor.publish_status(status)
+        needs_result_cleanup = status.status == ExecutionPhase.COMPLETED
+        await state.mark_published(
+            query.query_id, needs_result_cleanup=needs_result_cleanup
         )
-    await processor.publish_status(status)
+
+    try:
+        await processor.cleanup_query(
+            query, logger, needs_result_cleanup=needs_result_cleanup
+        )
+    except Exception as e:
+        await report_exception(e, slack_client=factory.slack_client)
+        logger.exception("Cleanup failed for finished query, will retry")
+        raise Retry(defer=config.backend_retry_delay) from e

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -122,13 +122,12 @@ async def test_immediate(
         assert timestamp <= elapsed + timedelta(seconds=10)
 
     # These time fields shouldn't include the Kafka delay.
-    for field in (
-        "qserv_elapsed",
-        "result_elapsed",
-        "submit_elapsed",
-        "delete_elapsed",
-    ):
+    for field in ("qserv_elapsed", "result_elapsed", "submit_elapsed"):
         assert timedelta(seconds=0) <= getattr(event, field) <= elapsed
+
+    # Timing of delete is not available now that result deletion is
+    # deferred until after the status is published.
+    assert event.delete_elapsed is None
 
     # Check the calculated rates.
     assert event.rate == event.encoded_size / event.elapsed.total_seconds()

--- a/tests/support/query.py
+++ b/tests/support/query.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from structlog.stdlib import get_logger
 from vo_models.uws.types import ExecutionPhase
 
 from qservkafka.factory import Factory
@@ -50,4 +51,10 @@ async def start_and_complete_immediate(
     assert query
 
     result_processor = factory.create_result_processor()
-    return await result_processor.build_query_status(query)
+    status = await result_processor.build_query_status(query)
+    needs_result_cleanup = status.status == ExecutionPhase.COMPLETED
+    logger = get_logger("qservkafka")
+    await result_processor.cleanup_query(
+        query, logger, needs_result_cleanup=needs_result_cleanup
+    )
+    return status


### PR DESCRIPTION
## Description

The issue this PR is addressing is that users had to wait for Qserv result/database cleanup before receiving their job's success or failure status (via Kafka).

The fix here is to change the order so that we first publish the status, then clean up the back end resources (Qserv result rows, temp upload tables, rate limits, internal state) after in the `handle_finished_query` arq worker and cancellation. 

Cleanup failures are retried via arq (Retry) and to make sure this is idempotent, I'm adding two new fields on the persisted query state (`result_published` & `needs_result_cleanup`).