### PR TITLE
DM-55758: Only delete successfully uploaded databases

### DIFF
--- a/changelog.d/20260807_114747_rra_DM_55758.md
+++ b/changelog.d/20260807_114747_rra_DM_55758.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- After temporary table upload failure, only try to delete temporary databases that were successfully created.

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -329,9 +329,11 @@ class QueryService:
         metadata = job.to_job_metadata()
 
         # Upload any tables.
+        uploaded = set()
         try:
             for upload in job.upload_tables:
                 stats = await self._backend.upload_table(upload)
+                uploaded.add(upload.database)
                 logger.info("Uploaded table", table_name=upload.table_name)
                 event = TemporaryTableUploadEvent(
                     job_id=job.job_id,
@@ -348,7 +350,7 @@ class QueryService:
                 msg = "Unable to upload table"
             await report_exception(e, self._slack_client)
             logger.exception(msg, error=str(e))
-            await self._results.delete_upload_databases(job, logger)
+            await self._results.delete_upload_databases(job, logger, uploaded)
             return JobStatus(
                 job_id=job.job_id,
                 execution_id=None,

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -464,7 +464,10 @@ class ResultProcessor(ABC):
         )
 
     async def delete_upload_databases(
-        self, job: JobRun, logger: BoundLogger
+        self,
+        job: JobRun,
+        logger: BoundLogger,
+        databases: set[str] | None = None,
     ) -> None:
         """Delete any temporary databases created for uploaded tables.
 
@@ -474,15 +477,19 @@ class ResultProcessor(ABC):
             Job metadata.
         logger
             Logger to use.
+        databases
+            If given, the databases to delete. Otherwise, all databases in the
+            list of tables to upload will be deleted.
         """
-        databases_to_delete = {t.database for t in job.upload_tables}
+        if databases is None:
+            databases = {t.database for t in job.upload_tables}
         logger.debug(
             "Deleting upload databases",
             upload_table_count=len(job.upload_tables),
             upload_table_types=[type(t).__name__ for t in job.upload_tables],
-            databases=list(databases_to_delete),
+            databases=list(databases),
         )
-        for database in databases_to_delete:
+        for database in databases:
             try:
                 await self._backend.delete_database(database)
                 logger.debug("Deleted upload database", database_name=database)


### PR DESCRIPTION
After temporary table upload failure, only try to delete temporary databases that were successfully created.