### PR TITLE
DM-55758: Refactor JobStatus construction

### DIFF
--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, override
+from typing import Annotated, Any, Literal, Self, override
 
 from pydantic import (
     BaseModel,
@@ -19,6 +19,7 @@ from safir.pydantic import SecondsTimedelta
 from vo_models.uws.types import ExecutionPhase
 
 from .progress import ProgressMetrics
+from .query import QueryStatus
 from .votable import VOTableArraySize, VOTablePrimitive
 
 type DatetimeMillis = Annotated[
@@ -254,6 +255,7 @@ class UploadTablePartitionType(StrEnum):
 
 
 def _partition_type_discriminator(v: Any) -> str:
+    """Union discriminator for upload table partitioning type."""
     if isinstance(v, dict):
         val = v.get("partitionType", v.get("partition_type"))
     else:
@@ -535,6 +537,15 @@ class JobRun(BaseModel):
         ),
     ] = None
 
+    def to_logging_context(self) -> dict[str, Any]:
+        """Convert job status details to a logging context."""
+        metadata = self.to_job_metadata()
+        return {
+            "job_id": self.job_id,
+            "username": self.owner,
+            "query": metadata.model_dump(mode="json", exclude_none=True),
+        }
+
     def to_job_metadata(self) -> JobMetadata:
         """Convert to the job metadata used in status responses."""
         return JobMetadata(query=self.query, database=self.database)
@@ -642,6 +653,29 @@ class JobError(BaseModel):
         ),
     ]
 
+    @classmethod
+    def for_quota_exceeded(cls, used: int, quota: int) -> Self:
+        """Generate an error object for a quota exceeded error.
+
+        Parameters
+        ----------
+        used
+            Number of running queries.
+        quota
+            Maximum allowed number of concurrent running queries.
+
+        Returns
+        -------
+        JobError
+            Corresponding error component of a Kafka job status message.
+        """
+        error = (
+            f"Maximum running queries reached ({used} running, maximum"
+            f" {quota}); wait for a query to finish or cancel one of your"
+            " running queries"
+        )
+        return cls(code=JobErrorCode.quota_exceeded, message=error)
+
 
 class JobStatus(BaseModel):
     """Status of a TAP query."""
@@ -714,3 +748,63 @@ class JobStatus(BaseModel):
     ] = None
 
     metadata: Annotated[JobMetadata, Field(title="Job metadata")]
+
+    @classmethod
+    def from_abort(
+        cls, job: JobRun, status: QueryStatus, start: datetime
+    ) -> Self:
+        """Construct from an underlying `QueryStatus`.
+
+        Parameters
+        ----------
+        job
+            Job for which to create a status message.
+        status
+            Underlying query status.
+        start
+            Start time of the query.
+
+        Returns
+        -------
+        JobStatus
+            Job status message for Kafka.
+        """
+        return cls(
+            job_id=job.job_id,
+            execution_id=status.query_id,
+            timestamp=status.last_update or datetime.now(tz=UTC),
+            status=ExecutionPhase.EXECUTING,
+            query_info=JobQueryInfo(
+                start_time=start, progress=status.progress
+            ),
+            metadata=job.to_job_metadata(),
+        )
+
+    @classmethod
+    def from_error(
+        cls, job: JobRun, error: JobError, execution_id: str | None = None
+    ) -> Self:
+        """Construct from an underlying `JobError`.
+
+        Parameters
+        ----------
+        job
+            Job for which to create a status message.
+        error
+            Error to report.
+        execution_id
+            Backend execution ID, if one is known.
+
+        Returns
+        -------
+        JobStatus
+            Job status message for Kafka.
+        """
+        return cls(
+            job_id=job.job_id,
+            execution_id=execution_id,
+            timestamp=datetime.now(tz=UTC),
+            status=ExecutionPhase.ERROR,
+            error=error,
+            metadata=job.to_job_metadata(),
+        )

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -5,9 +5,11 @@ from typing import Annotated, Any, Self, override
 
 from pydantic import BaseModel, Field, model_validator
 from safir.datetime import format_datetime_for_logging
+from vo_models.uws.types import ExecutionPhase
 
-from .kafka import JobQueryInfo, JobRun
+from .kafka import JobError, JobQueryInfo, JobResultInfo, JobRun, JobStatus
 from .query import QueryStatus
+from .votable import UploadStats
 
 __all__ = [
     "Query",
@@ -108,6 +110,22 @@ class RunningQuery(Query):
             result_queued=False,
         )
 
+    def to_completed_job_status(self, stats: UploadStats) -> JobStatus:
+        """Construct a Kafka job status message for a completed query."""
+        return JobStatus(
+            job_id=self.job.job_id,
+            execution_id=self.query_id,
+            timestamp=datetime.now(tz=UTC),
+            status=ExecutionPhase.COMPLETED,
+            query_info=self.to_job_query_info(finished=True),
+            result_info=JobResultInfo(
+                total_rows=stats.rows,
+                result_location=self.job.result_location,
+                format=self.job.result_format.format,
+            ),
+            metadata=self.job.to_job_metadata(),
+        )
+
     def to_job_query_info(self, *, finished: bool = False) -> JobQueryInfo:
         """Build job query information based on query status.
 
@@ -126,6 +144,23 @@ class RunningQuery(Query):
             start_time=self.start,
             progress=self.status.progress,
             end_time=datetime.now(tz=UTC) if finished else None,
+        )
+
+    def to_job_status(
+        self,
+        status: ExecutionPhase = ExecutionPhase.EXECUTING,
+        error: JobError | None = None,
+    ) -> JobStatus:
+        """Construct a Kafka job status message from the query."""
+        finished = status != ExecutionPhase.EXECUTING
+        return JobStatus(
+            job_id=self.job.job_id,
+            execution_id=self.query_id,
+            timestamp=self.status.last_update or datetime.now(tz=UTC),
+            status=status,
+            query_info=self.to_job_query_info(finished=finished),
+            error=error,
+            metadata=self.job.to_job_metadata(),
         )
 
     @override

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -6,7 +6,6 @@ from safir.arq import ArqQueue
 from safir.sentry import report_exception
 from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
-from vo_models.uws.types import ExecutionPhase
 
 from ..config import config
 from ..events import Events, TemporaryTableUploadEvent
@@ -191,10 +190,6 @@ class QueryService:
         JobStatus
             Initial status of the job.
         """
-        metadata = job.to_job_metadata()
-        query_for_logging = metadata.model_dump(mode="json", exclude_none=True)
-
-        # Check that the job request is supported.
         result_type = job.result_format.format.type
         serialization = job.result_format.format.serialization
         if result_type == JobResultType.VOTable:
@@ -219,11 +214,9 @@ class QueryService:
 
         # Set up the logger for the query.
         logger = self._logger.bind(
-            job_id=job.job_id,
-            username=job.owner,
             quota=quota.to_logging_context() if quota else None,
             running=count,
-            query=query_for_logging,
+            **job.to_logging_context(),
         )
 
         # Start the query.
@@ -234,7 +227,7 @@ class QueryService:
             raise
 
     def _build_invalid_request_status(
-        self, job: JobRun, error: str
+        self, job: JobRun, message: str
     ) -> JobStatus:
         """Build a status reply for an invalid request.
 
@@ -242,7 +235,7 @@ class QueryService:
         ----------
         job
             Initial query request.
-        error
+        message
             Error message.
 
         Returns
@@ -250,23 +243,12 @@ class QueryService:
         JobStatus
             Job status to report to Kafka.
         """
-        metadata = job.to_job_metadata()
-        self._logger.warning(
-            error,
-            job_id=job.job_id,
-            username=job.owner,
-            query=metadata.model_dump(mode="json", exclude_none=True),
-        )
-        return JobStatus(
-            job_id=job.job_id,
-            timestamp=datetime.now(tz=UTC),
-            status=ExecutionPhase.ERROR,
-            error=JobError(code=JobErrorCode.invalid_request, message=error),
-            metadata=metadata,
-        )
+        self._logger.warning(message, **job.to_logging_context())
+        error = JobError(code=JobErrorCode.invalid_request, message=message)
+        return JobStatus.from_error(job, error)
 
     def _build_quota_status(
-        self, job: JobRun, count: int, quota: int
+        self, job: JobRun, running: int, quota: int
     ) -> JobStatus:
         """Build a status reply for an over-quota request.
 
@@ -274,7 +256,7 @@ class QueryService:
         ----------
         job
             Initial query request.
-        count
+        running
             Number of running queries.
         quota
             Maximum allowed number of concurrent running queries.
@@ -284,27 +266,14 @@ class QueryService:
         JobStatus
             Job status to report to Kafka.
         """
-        metadata = job.to_job_metadata()
         self._logger.info(
             "Query rejected due to quota",
-            job_id=job.job_id,
-            username=job.owner,
             quota={"concurrent": quota},
-            running=count,
-            query=metadata.model_dump(mode="json", exclude_none=True),
+            running=running,
+            **job.to_logging_context(),
         )
-        error = (
-            f"Maximum running queries reached ({count} running, maximum"
-            f" {quota}); wait for a query to finish or cancel one of your"
-            " running queries"
-        )
-        return JobStatus(
-            job_id=job.job_id,
-            timestamp=datetime.now(tz=UTC),
-            status=ExecutionPhase.ERROR,
-            error=JobError(code=JobErrorCode.quota_exceeded, message=error),
-            metadata=metadata,
-        )
+        error = JobError.for_quota_exceeded(running, quota)
+        return JobStatus.from_error(job, error)
 
     async def _start_query_internal(
         self, job: JobRun, kafka_start: datetime | None, logger: BoundLogger
@@ -326,7 +295,6 @@ class QueryService:
             Initial status of the job.
         """
         start = datetime.now(tz=UTC)
-        metadata = job.to_job_metadata()
 
         # Upload any tables.
         uploaded = set()
@@ -351,14 +319,7 @@ class QueryService:
             await report_exception(e, self._slack_client)
             logger.exception(msg, error=str(e))
             await self._results.delete_upload_databases(job, logger, uploaded)
-            return JobStatus(
-                job_id=job.job_id,
-                execution_id=None,
-                timestamp=datetime.now(tz=UTC),
-                status=ExecutionPhase.ERROR,
-                error=e.to_job_error(),
-                metadata=metadata,
-            )
+            return JobStatus.from_error(job, e.to_job_error())
 
         # Start the query.
         query_id = None
@@ -374,14 +335,9 @@ class QueryService:
                 await report_exception(e, self._slack_client)
                 logger.exception("Unable to start query", error=str(e))
             await self._results.delete_upload_databases(job, logger)
-            return JobStatus(
-                job_id=job.job_id,
-                execution_id=str(query_id) if query_id else None,
-                timestamp=datetime.now(tz=UTC),
-                status=ExecutionPhase.ERROR,
-                error=e.to_job_error(),
-                metadata=metadata,
-            )
+            return JobStatus.from_error(job, e.to_job_error())
+
+        # Record the time at which the query was started.
         created = datetime.now(tz=UTC)
         logger.info("Started query", backend_id=query_id)
 

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -32,13 +32,7 @@ from ..exceptions import (
     UploadTimeoutError,
     UploadWebError,
 )
-from ..models.kafka import (
-    JobError,
-    JobErrorCode,
-    JobResultInfo,
-    JobRun,
-    JobStatus,
-)
+from ..models.kafka import JobError, JobErrorCode, JobRun, JobStatus
 from ..models.query import AsyncQueryPhase
 from ..models.state import Query, RunningQuery
 from ..models.votable import UploadStats
@@ -116,14 +110,7 @@ class ResultProcessor(ABC):
             Job status to report to Kafka.
         """
         self._logger.debug("Query is executing", **query.to_logging_context())
-        return JobStatus(
-            job_id=query.job.job_id,
-            execution_id=str(query.query_id),
-            timestamp=query.status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.EXECUTING,
-            query_info=query.to_job_query_info(),
-            metadata=query.job.to_job_metadata(),
-        )
+        return query.to_job_status()
 
     async def build_query_status(
         self, query: Query, *, initial: bool = False
@@ -155,16 +142,10 @@ class ResultProcessor(ABC):
         except BackendApiError as e:
             await report_exception(e, slack_client=self._slack_client)
             logger.exception("Unable to get job status", error=str(e))
-            update = JobStatus(
-                job_id=query.job.job_id,
-                execution_id=str(query.query_id),
-                timestamp=datetime.now(tz=UTC),
-                status=ExecutionPhase.ERROR,
-                error=e.to_job_error(),
-                metadata=query.job.to_job_metadata(),
-            )
             await self._delete_query_data(query, logger)
-            return update
+            return JobStatus.from_error(
+                query.job, e.to_job_error(), query.query_id
+            )
         full_query = RunningQuery.from_query(query, status)
         logger = self._logger.bind(**full_query.to_logging_context())
 
@@ -274,14 +255,7 @@ class ResultProcessor(ABC):
             elapsed=timestamp - query.start,
         )
         await self._events.query_abort.publish(event)
-        return JobStatus(
-            job_id=query.job.job_id,
-            execution_id=str(query.query_id),
-            timestamp=query.status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.ABORTED,
-            query_info=query.to_job_query_info(finished=True),
-            metadata=query.job.to_job_metadata(),
-        )
+        return query.to_job_status(ExecutionPhase.ABORTED)
 
     async def _build_completed_status(self, query: RunningQuery) -> JobStatus:
         """Retrieve results and construct status for a completed job.
@@ -345,19 +319,7 @@ class ResultProcessor(ABC):
         )
 
         # Return the resulting status.
-        return JobStatus(
-            job_id=query.job.job_id,
-            execution_id=str(query.query_id),
-            timestamp=datetime.now(tz=UTC),
-            status=ExecutionPhase.COMPLETED,
-            query_info=query.to_job_query_info(finished=True),
-            result_info=JobResultInfo(
-                total_rows=stats.rows,
-                result_location=query.job.result_location,
-                format=query.job.result_format.format,
-            ),
-            metadata=query.job.to_job_metadata(),
-        )
+        return query.to_completed_job_status(stats)
 
     async def _build_exception_status(
         self, query: RunningQuery, exc: QueryError
@@ -401,14 +363,7 @@ class ResultProcessor(ABC):
         await self._events.query_failure.publish(event)
 
         # Return the job status to send to Kafka.
-        return JobStatus(
-            job_id=query.job.job_id,
-            execution_id=str(query.query_id),
-            timestamp=now,
-            status=ExecutionPhase.ERROR,
-            error=error,
-            metadata=query.job.to_job_metadata(),
-        )
+        return JobStatus.from_error(query.job, error, query.query_id)
 
     async def _build_failed_status(self, query: RunningQuery) -> JobStatus:
         """Build the status for a failed job.
@@ -453,15 +408,8 @@ class ResultProcessor(ABC):
             elapsed=datetime.now(tz=UTC) - query.start,
         )
         await self._events.query_failure.publish(event)
-        return JobStatus(
-            job_id=query.job.job_id,
-            execution_id=str(query.query_id),
-            timestamp=query.status.last_update or datetime.now(tz=UTC),
-            status=ExecutionPhase.ERROR,
-            query_info=query.to_job_query_info(finished=True),
-            error=JobError(code=code, message=error),
-            metadata=metadata,
-        )
+        job_error = JobError(code=code, message=error)
+        return query.to_job_status(ExecutionPhase.ERROR, job_error)
 
     async def delete_upload_databases(
         self,


### PR DESCRIPTION
Move the pure data manipulation code for constructing `JobStatus` into either the `RunningQuery` or the `JobStatus` model classes. Add `to_logging_context` to `JobRun` and use that to construct a logger in more places.