### PR TITLE
DM-55758: Simplify and restructure some internal models

### DIFF
--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -160,15 +160,6 @@ class QuerySuccessEvent(BaseQueryEvent):
         description="Number of uploaded tables provided as part of the query",
     )
 
-    immediate: bool = Field(
-        False,
-        title="Query finished immediately",
-        description=(
-            "Whether the query had already completed before its"
-            " status was first checked"
-        ),
-    )
-
     def to_logging_context(self) -> dict[str, Any]:
         """Convert relevant information to a dictionary for logging.
 

--- a/src/qservkafka/models/progress.py
+++ b/src/qservkafka/models/progress.py
@@ -80,6 +80,19 @@ class ChunkProgress(BaseModel):
             or self.completed_chunks != other.completed_chunks
         )
 
+    def to_logging_context(self) -> dict[str, str | float]:
+        """Get progress fields for logging context.
+
+        Returns
+        -------
+        dict
+            Dictionary of field names to values for logging.
+        """
+        return {
+            "total_chunks": self.total_chunks,
+            "completed_chunks": self.completed_chunks,
+        }
+
 
 class ByteProgress(BaseModel):
     """BigQuery-style byte-based progress reporting.
@@ -128,6 +141,23 @@ class ByteProgress(BaseModel):
 
     def to_human_readable(self) -> str:
         return humanize.naturalsize(self.bytes_processed, binary=True)
+
+    def to_logging_context(self) -> dict[str, str | float]:
+        """Get progress fields for logging context.
+
+        Returns
+        -------
+        dict
+            Dictionary of field names to values for logging.
+        """
+        result: dict[str, str | float] = {
+            "bytes_processed": self.bytes_processed,
+            "bytes_processed_human": self.to_human_readable(),
+        }
+        if self.bytes_billed is not None:
+            result["bytes_billed"] = self.bytes_billed
+        result["cached"] = self.cached
+        return result
 
     def is_different_than(self, other: ProgressMetrics) -> bool:
         """Check if progress has changed.

--- a/src/qservkafka/models/qserv.py
+++ b/src/qservkafka/models/qserv.py
@@ -152,14 +152,10 @@ class QservAsyncStatusData(BaseModel):
         QservQueryStatus
             Query status for Qserv backend.
         """
-        qserv_phase = QservQueryPhase(self.status)
-        generic_phase = qserv_phase.to_generic_phase()
-        results_too_large = qserv_phase == QservQueryPhase.FAILED_LR
-
         return QservQueryStatus(
             backend_type="Qserv",
             query_id=str(self.query_id),
-            status=generic_phase,
+            status=self.status.to_generic_phase(),
             query_begin=self.query_begin,
             last_update=self.last_update,
             error=self.error,
@@ -171,7 +167,7 @@ class QservAsyncStatusData(BaseModel):
             ),
             czar_id=self.czar_id,
             czar_type=self.czar_type,
-            results_too_large=results_too_large,
+            results_too_large=self.status == QservQueryPhase.FAILED_LR,
         )
 
 

--- a/src/qservkafka/models/query.py
+++ b/src/qservkafka/models/query.py
@@ -65,6 +65,21 @@ class QueryStatusBase(BaseModel, ABC):
         ),
     ] = False
 
+    @property
+    @abstractmethod
+    def progress(self) -> ProgressMetrics | None:
+        """Backend-specific progress."""
+
+    @abstractmethod
+    def to_logging_context(self) -> dict[str, Any]:
+        """Get backend-specific fields for logging context.
+
+        Returns
+        -------
+        dict
+            Dictionary of field names to values for logging.
+        """
+
     def to_process_status(self) -> ProcessStatus:
         """Extract minimal process status for monitoring.
 
@@ -114,21 +129,6 @@ class QueryStatusBase(BaseModel, ABC):
     def update_progress_from(self, progress: ProgressMetrics | None) -> None:
         """Update progress from a `ProcessStatus`."""
 
-    @property
-    @abstractmethod
-    def progress(self) -> ProgressMetrics | None:
-        """Backend-specific progress."""
-
-    @abstractmethod
-    def to_logging_context(self) -> dict[str, Any]:
-        """Get backend-specific fields for logging context.
-
-        Returns
-        -------
-        dict
-            Dictionary of field names to values for logging.
-        """
-
 
 class QservQueryStatus(QueryStatusBase):
     """Query status for Qserv backend.
@@ -156,12 +156,6 @@ class QservQueryStatus(QueryStatusBase):
         """Chunk-based progress for Qserv queries."""
         return self.chunk_progress
 
-    @override
-    def update_progress_from(self, progress: ProgressMetrics | None) -> None:
-        """Update chunk progress from `ProcessStatus`."""
-        if isinstance(progress, ChunkProgress):
-            self.chunk_progress = progress
-
     def get_completion_percentage(self) -> float | None:
         """Get completion percentage from chunk progress.
 
@@ -179,9 +173,16 @@ class QservQueryStatus(QueryStatusBase):
         """Get Qserv-specific fields for logging context."""
         result: dict[str, Any] = {}
         if self.chunk_progress:
-            result["total_chunks"] = self.chunk_progress.total_chunks
-            result["completed_chunks"] = self.chunk_progress.completed_chunks
+            result.update(self.chunk_progress.to_logging_context())
+        if self.collected_bytes:
+            result["qserv_size"] = self.collected_bytes
         return result
+
+    @override
+    def update_progress_from(self, progress: ProgressMetrics | None) -> None:
+        """Update chunk progress from `ProcessStatus`."""
+        if isinstance(progress, ChunkProgress):
+            self.chunk_progress = progress
 
 
 class BigQueryQueryStatus(QueryStatusBase):
@@ -206,24 +207,20 @@ class BigQueryQueryStatus(QueryStatusBase):
         return self.byte_progress
 
     @override
-    def update_progress_from(self, progress: ProgressMetrics | None) -> None:
-        """Update byte progress from ProcessStatus."""
-        if isinstance(progress, ByteProgress):
-            self.byte_progress = progress
-
-    @override
     def to_logging_context(self) -> dict[str, Any]:
         """Get BigQuery-specific fields for logging context."""
         result: dict[str, Any] = {}
         if self.byte_progress:
-            result["bytes_processed"] = self.byte_progress.bytes_processed
-            result["bytes_processed_human"] = (
-                self.byte_progress.to_human_readable()
-            )
-            if self.byte_progress.bytes_billed is not None:
-                result["bytes_billed"] = self.byte_progress.bytes_billed
-            result["cached"] = self.byte_progress.cached
+            result.update(self.byte_progress.to_logging_context())
+        if self.collected_bytes:
+            result["bigquery_size"] = self.collected_bytes
         return result
+
+    @override
+    def update_progress_from(self, progress: ProgressMetrics | None) -> None:
+        """Update byte progress from ProcessStatus."""
+        if isinstance(progress, ByteProgress):
+            self.byte_progress = progress
 
 
 type QueryStatus = Annotated[

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -14,13 +14,12 @@ from .votable import UploadStats
 __all__ = [
     "Query",
     "RunningQuery",
+    "StartedQuery",
 ]
 
 
 class Query(BaseModel):
     """Represents a started query with no backend status."""
-
-    query_id: Annotated[str, Field(title="ID of query")]
 
     queued: Annotated[
         datetime | None, Field(title="Kafka queue time of query")
@@ -28,28 +27,56 @@ class Query(BaseModel):
 
     start: Annotated[datetime, Field(title="Receipt time of query")]
 
-    created: Annotated[datetime, Field(title="Creation time of query")]
-
     job: Annotated[JobRun, Field(title="Full job request")]
-
-    immediate: Annotated[
-        bool, Field(title="Whether query completed before first status check")
-    ] = False
 
     def to_logging_context(self) -> dict[str, str | float]:
         """Convert to variables for a structlog logging context."""
-        result: dict[str, str | float] = {
-            "job_id": self.job.job_id,
-            "backend_id": self.query_id,
-            "username": self.job.owner,
-            "start_time": format_datetime_for_logging(self.start),
-        }
+        result = self.job.to_logging_context()
         if self.queued:
             result["queued"] = format_datetime_for_logging(self.queued)
+        result["start_time"] = format_datetime_for_logging(self.start)
         return result
 
 
-class RunningQuery(Query):
+class StartedQuery(Query):
+    """Represents a query that has been dispatched to the backend."""
+
+    query_id: Annotated[str, Field(title="ID of query")]
+
+    created: Annotated[datetime, Field(title="Creation time of query")]
+
+    @classmethod
+    def from_query(cls, query: Query, query_id: str) -> Self:
+        """Convert a new query to a started query.
+
+        Parameters
+        ----------
+        query
+            New query.
+        query_id
+            Backend query ID.
+
+        Returns
+        -------
+        StartedQuery
+            Query state.
+        """
+        return cls(
+            query_id=query_id,
+            queued=query.queued,
+            start=query.start,
+            created=datetime.now(tz=UTC),
+            job=query.job,
+        )
+
+    @override
+    def to_logging_context(self) -> dict[str, str | float]:
+        results = super().to_logging_context()
+        results["backend_id"] = self.query_id
+        return results
+
+
+class RunningQuery(StartedQuery):
     """Represents a running query with a known status."""
 
     status: Annotated[QueryStatus, Field(title="Last known status")]
@@ -84,7 +111,9 @@ class RunningQuery(Query):
         return data
 
     @classmethod
-    def from_query(cls, query: Query, status: QueryStatus) -> Self:
+    def from_started_query(
+        cls, query: StartedQuery, status: QueryStatus
+    ) -> Self:
         """Convert a started query to full query state by recording status.
 
         Parameters
@@ -105,7 +134,6 @@ class RunningQuery(Query):
             start=query.start,
             created=query.created,
             job=query.job,
-            immediate=query.immediate,
             status=status,
             result_queued=False,
         )
@@ -167,10 +195,4 @@ class RunningQuery(Query):
     def to_logging_context(self) -> dict[str, Any]:
         result = super().to_logging_context()
         result.update(self.status.to_logging_context())
-        if self.status.collected_bytes:
-            match self.status.backend_type:
-                case "Qserv":
-                    result["qserv_size"] = self.status.collected_bytes
-                case "BigQuery":
-                    result["bigquery_size"] = self.status.collected_bytes
         return result

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -24,7 +24,7 @@ from ..models.kafka import (
     JobStatus,
 )
 from ..models.query import AsyncQueryPhase
-from ..models.state import Query
+from ..models.state import Query, StartedQuery
 from ..storage.backend import DatabaseBackend
 from ..storage.gafaelfawr import GafaelfawrStorage
 from ..storage.rate import RateLimitStore
@@ -212,19 +212,28 @@ class QueryService:
             await self._rate_store.end_query(job.owner)
             return self._build_quota_status(job, count - 1, quota.concurrent)
 
-        # Set up the logger for the query.
+        # Create the query and set up the logger for it.
+        query = Query(queued=kafka_start, job=job, start=datetime.now(tz=UTC))
         logger = self._logger.bind(
             quota=quota.to_logging_context() if quota else None,
             running=count,
-            **job.to_logging_context(),
+            **query.to_logging_context(),
         )
 
         # Start the query.
         try:
-            return await self._start_query_internal(job, kafka_start, logger)
+            started_query = await self._start_query_internal(query, logger)
+        except (BackendApiError, TableUploadWebError) as e:
+            await self._rate_store.end_query(job.owner)
+            return JobStatus.from_error(query.job, e.to_job_error())
         except Exception:
             await self._rate_store.end_query(job.owner)
             raise
+
+        # Update the query status and return the status message to send.
+        return await self._results.build_query_status(
+            started_query, initial=True
+        )
 
     def _build_invalid_request_status(
         self, job: JobRun, message: str
@@ -276,77 +285,62 @@ class QueryService:
         return JobStatus.from_error(job, error)
 
     async def _start_query_internal(
-        self, job: JobRun, kafka_start: datetime | None, logger: BoundLogger
-    ) -> JobStatus:
-        """Start a query after verification and rate limiting.
+        self, query: Query, logger: BoundLogger
+    ) -> StartedQuery:
+        """Start a query by dispatching it to the backend.
 
         Parameters
         ----------
-        job
-            Query job to start.
-        kafka_start
-            Time at which the Kafka message for the job was queued.
+        query
+            Query to start.
         logger
             Logger to use for any messages.
 
         Returns
         -------
-        JobStatus
-            Initial status of the job.
+        StartedQuery
+            Started query with backend job ID.
         """
-        start = datetime.now(tz=UTC)
-
         # Upload any tables.
         uploaded = set()
         try:
-            for upload in job.upload_tables:
+            for upload in query.job.upload_tables:
                 stats = await self._backend.upload_table(upload)
                 uploaded.add(upload.database)
                 logger.info("Uploaded table", table_name=upload.table_name)
                 event = TemporaryTableUploadEvent(
-                    job_id=job.job_id,
-                    username=job.owner,
+                    job_id=query.job.job_id,
+                    username=query.job.owner,
                     size=stats.size,
                     elapsed=stats.elapsed,
                 )
                 await self._events.temporary_table.publish(event)
         except (BackendApiError, TableUploadWebError) as e:
-            await self._rate_store.end_query(job.owner)
+            await self._rate_store.end_query(query.job.owner)
             if isinstance(e, TableUploadWebError):
                 msg = "Unable to retrieve table to upload"
             else:
                 msg = "Unable to upload table"
             await report_exception(e, self._slack_client)
             logger.exception(msg, error=str(e))
-            await self._results.delete_upload_databases(job, logger, uploaded)
-            return JobStatus.from_error(job, e.to_job_error())
+            await self._results.delete_uploaded_databases(query.job, uploaded)
+            raise
 
         # Start the query.
         query_id = None
         try:
-            query_id = await self._backend.submit_query(job)
+            query_id = await self._backend.submit_query(query.job)
         except BackendApiError as e:
-            await self._rate_store.end_query(job.owner)
+            await self._rate_store.end_query(query.job.owner)
             if isinstance(e, BackendApiFailedError):
-                logger.info(
-                    "Query rejected by backend", **e.to_logging_context()
-                )
+                logger = logger.bind(**e.to_logging_context())
+                logger.info("Query rejected by backend")
             else:
                 await report_exception(e, self._slack_client)
                 logger.exception("Unable to start query", error=str(e))
-            await self._results.delete_upload_databases(job, logger)
-            return JobStatus.from_error(job, e.to_job_error())
+            await self._results.delete_uploaded_databases(query.job)
+            raise
 
-        # Record the time at which the query was started.
-        created = datetime.now(tz=UTC)
+        # Return the corresponding StartedQuery object.
         logger.info("Started query", backend_id=query_id)
-
-        # Analyze the initial status and return it.
-        query = Query(
-            query_id=query_id,
-            queued=kafka_start,
-            job=job,
-            start=start,
-            created=created,
-        )
-        return await self._results.build_query_status(query, initial=True)
+        return StartedQuery.from_query(query, query_id)

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -34,7 +34,7 @@ from ..exceptions import (
 )
 from ..models.kafka import JobError, JobErrorCode, JobRun, JobStatus
 from ..models.query import AsyncQueryPhase
-from ..models.state import Query, RunningQuery
+from ..models.state import RunningQuery, StartedQuery
 from ..models.votable import UploadStats
 from ..storage.backend import DatabaseBackend
 from ..storage.rate import RateLimitStore
@@ -113,7 +113,7 @@ class ResultProcessor(ABC):
         return query.to_job_status()
 
     async def build_query_status(
-        self, query: Query, *, initial: bool = False
+        self, query: StartedQuery, *, initial: bool = False
     ) -> JobStatus:
         """Retrieve query status and convert it to a job status update.
 
@@ -146,7 +146,7 @@ class ResultProcessor(ABC):
             return JobStatus.from_error(
                 query.job, e.to_job_error(), query.query_id
             )
-        full_query = RunningQuery.from_query(query, status)
+        full_query = RunningQuery.from_started_query(query, status)
         logger = self._logger.bind(**full_query.to_logging_context())
 
         # Based on the status, process the results.
@@ -164,7 +164,6 @@ class ResultProcessor(ABC):
                 # Dispatch to the worker pool and report the job as
                 # still executing.
                 full_query.result_queued = True
-                full_query.immediate = True
                 await self._state.store_query(full_query)
                 await self._arq.enqueue(
                     "handle_finished_query", query.query_id
@@ -181,6 +180,64 @@ class ResultProcessor(ABC):
         # resulting status.
         await self._delete_query_data(query, logger)
         return result
+
+    async def delete_uploaded_databases(
+        self,
+        job: JobRun,
+        databases: set[str] | None = None,
+    ) -> None:
+        """Delete any temporary databases created for uploaded tables.
+
+        Parameters
+        ----------
+        job
+            Job metadata.
+        databases
+            If given, the databases to delete. Otherwise, all databases in the
+            list of tables to upload will be deleted.
+        """
+        logger = self._logger.bind(**job.to_logging_context())
+        if databases is None:
+            databases = {t.database for t in job.upload_tables}
+        logger.debug(
+            "Deleting upload databases",
+            upload_table_count=len(job.upload_tables),
+            upload_table_types=[type(t).__name__ for t in job.upload_tables],
+            databases=list(databases),
+        )
+        for database in databases:
+            try:
+                await self._backend.delete_database(database)
+                logger.debug("Deleted upload database", database_name=database)
+            except BackendApiError as e:
+                await report_exception(e, slack_client=self._slack_client)
+                logger.exception(
+                    "Unable to delete temporary database, orphaning it",
+                    error=str(e),
+                    database_name=database,
+                )
+
+    async def handle_completed_query(self, query: RunningQuery) -> JobStatus:
+        """Process a completed query.
+
+        This method should only be called when the caller already knows the
+        backend has indicated that the query has completed, such as from a
+        result processing worker.
+
+        Parameters
+        ----------
+        query
+            Query whose results should be processed.
+
+        Returns
+        -------
+        JobStatus
+            Job status message to send to Kafka.
+        """
+        logger = self._logger.bind(**query.to_logging_context())
+        status = await self._build_completed_status(query)
+        await self._delete_query_data(query, logger)
+        return status
 
     async def publish_status(self, status: JobStatus) -> None:
         """Publish a status update to Kafka.
@@ -381,7 +438,6 @@ class ResultProcessor(ABC):
         JobStatus
             Status for the query.
         """
-        metadata = query.job.to_job_metadata()
         if query.status.results_too_large:
             msg = "Query failed in backend because results were too large"
             code = JobErrorCode.backend_results_too_large
@@ -395,12 +451,7 @@ class ResultProcessor(ABC):
             error = "Query failed in backend"
         if query.status.error:
             error = f"{error}: {query.status.error}"
-        self._logger.warning(
-            msg,
-            **query.to_logging_context(),
-            query=metadata.model_dump(mode="json", exclude_none=True),
-            status=query.status.model_dump(mode="json", exclude_none=True),
-        )
+        self._logger.warning(msg, **query.to_logging_context())
         event = QueryFailureEvent(
             job_id=query.job.job_id,
             username=query.job.owner,
@@ -411,46 +462,8 @@ class ResultProcessor(ABC):
         job_error = JobError(code=code, message=error)
         return query.to_job_status(ExecutionPhase.ERROR, job_error)
 
-    async def delete_upload_databases(
-        self,
-        job: JobRun,
-        logger: BoundLogger,
-        databases: set[str] | None = None,
-    ) -> None:
-        """Delete any temporary databases created for uploaded tables.
-
-        Parameters
-        ----------
-        job
-            Job metadata.
-        logger
-            Logger to use.
-        databases
-            If given, the databases to delete. Otherwise, all databases in the
-            list of tables to upload will be deleted.
-        """
-        if databases is None:
-            databases = {t.database for t in job.upload_tables}
-        logger.debug(
-            "Deleting upload databases",
-            upload_table_count=len(job.upload_tables),
-            upload_table_types=[type(t).__name__ for t in job.upload_tables],
-            databases=list(databases),
-        )
-        for database in databases:
-            try:
-                await self._backend.delete_database(database)
-                logger.debug("Deleted upload database", database_name=database)
-            except BackendApiError as e:
-                await report_exception(e, slack_client=self._slack_client)
-                logger.exception(
-                    "Unable to delete temporary database, orphaning it",
-                    error=str(e),
-                    database_name=database,
-                )
-
     async def _delete_query_data(
-        self, query: Query, logger: BoundLogger
+        self, query: StartedQuery, logger: BoundLogger
     ) -> None:
         """Delete stored information for the query.
 
@@ -470,7 +483,7 @@ class ResultProcessor(ABC):
         )
         await self._state.delete_query(query.query_id)
         await self._rate_store.end_query(query.job.owner)
-        await self.delete_upload_databases(query.job, logger)
+        await self.delete_uploaded_databases(query.job)
 
     async def _upload_results(self, query: RunningQuery) -> UploadStats:
         """Retrieve and upload the results.
@@ -605,7 +618,6 @@ class QservResultProcessor(ResultProcessor):
             qserv_rate=backend_rate,
             result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
             upload_tables=len(query.job.upload_tables),
-            immediate=query.immediate,
         )
         await self._events.qserv_success.publish(event)
         return event
@@ -650,7 +662,6 @@ class BigQueryResultProcessor(ResultProcessor):
             rate=stats.data_bytes / elapsed.total_seconds(),
             result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
             upload_tables=len(query.job.upload_tables),
-            immediate=query.immediate,
         )
         await self._events.bigquery_success.publish(event)
         return event

--- a/tests/data/events/success-kafka.json
+++ b/tests/data/events/success-kafka.json
@@ -2,7 +2,6 @@
   "delete_elapsed": "<ANY>",
   "elapsed": "<ANY>",
   "encoded_size": 244,
-  "immediate": false,
   "job_id": "uws123",
   "kafka_elapsed": "<ANY>",
   "qserv_elapsed": "<ANY>",

--- a/tests/data/events/success-no-delete.json
+++ b/tests/data/events/success-no-delete.json
@@ -2,7 +2,6 @@
   "delete_elapsed": null,
   "elapsed": "<ANY>",
   "encoded_size": 244,
-  "immediate": true,
   "job_id": "uws123",
   "kafka_elapsed": "<ANY>",
   "qserv_elapsed": "PT0S",

--- a/tests/data/events/success-upload.json
+++ b/tests/data/events/success-upload.json
@@ -2,7 +2,6 @@
   "delete_elapsed": "<ANY>",
   "elapsed": "<ANY>",
   "encoded_size": 244,
-  "immediate": true,
   "job_id": "uws123",
   "kafka_elapsed": "<ANY>",
   "qserv_elapsed": "PT0S",

--- a/tests/data/events/success.json
+++ b/tests/data/events/success.json
@@ -2,7 +2,6 @@
   "delete_elapsed": "<ANY>",
   "elapsed": "<ANY>",
   "encoded_size": 244,
-  "immediate": true,
   "job_id": "uws123",
   "kafka_elapsed": "<ANY>",
   "qserv_elapsed": "PT0S",

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -126,7 +126,7 @@ async def test_immediate(
     assert isinstance(factory.events.qserv_success, MockEventPublisher)
     events = factory.events.qserv_success.published
     assert len(events) == 1
-    assert events[0].immediate is True
+    data.assert_pydantic_matches(events[0], "events/success")
 
 
 @pytest.mark.asyncio

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -183,7 +183,6 @@ async def test_immediate_dispatch(
     query = await state_store.get_query("1")
     assert query
     assert query.result_queued
-    assert query.immediate
 
     result_processor = factory.create_result_processor()
     with patch.object(RedisArqQueue, "enqueue") as mock:

--- a/tests/support/query.py
+++ b/tests/support/query.py
@@ -50,4 +50,4 @@ async def start_and_complete_immediate(
     assert query
 
     result_processor = factory.create_result_processor()
-    return await result_processor.build_query_status(query)
+    return await result_processor.handle_completed_query(query)


### PR DESCRIPTION
Eliminate the `immediate` flag on event metrics, since result processing is now never done in the frontend and thus the flag no longer has much meaning.

Move more code for generating logging contexts into the appropriate models and out of the service code.

Add a `StartedQuery` separate from `Query` as an intermediate stage between it and `RunningQuery` so that the service code can assemble an object to pass around a bit earlier in the query creation process.