### PR TITLE
DM-55758: Restructure result handling

### DIFF
--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -36,7 +36,7 @@ async def job_cancel(
     context: Annotated[ConsumerContext, Depends(context_dependency)],
 ) -> None:
     query_service = context.factory.create_query_service()
-    await query_service.handle_cancel(message)
+    await query_service.cancel_query(message)
 
 
 def register_kafka_handlers(kafka_router: KafkaRouter) -> None:

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -7,6 +7,7 @@ from structlog.stdlib import BoundLogger
 
 from ..config import config
 from ..events import BigQueryExecutingEvent, Events, QservExecutingEvent
+from ..exceptions import QueryError
 from ..models.kafka import JobStatus
 from ..models.query import AsyncQueryPhase, ProcessStatus
 from ..models.state import RunningQuery
@@ -117,25 +118,25 @@ class QueryMonitor:
             return None
 
         # Send updates to executing queries directly from the background
-        # monitoring task for faster updates, but make sure we do not
-        # accidentally process finished queries from the monitor task. We
-        # otherwise might send duplicate updates. Ensure all finished queries
-        # are dispatched to arq.
-        #
-        # Do not use build_query_status inside the first block, since it will
-        # re-retrieve the status from the backend and may at that point find
-        # that it is completed.
+        # monitoring task for faster updates, but dispatch any completed
+        # queries to a result worker.
         if status and status.status == AsyncQueryPhase.EXECUTING:
             if not query.status.is_different_than(status):
                 logger.debug("Running query has not changed state")
                 return None
             query.status.update_from(status)
-            update = self._results.build_executing_status(query)
             await self._state.update_status(query.query_id, query.status)
-            logger = self._logger.bind(**query.to_logging_context())
             logger.debug("Sending status update for running query")
-            return update
+            return query.to_job_status()
         else:
+            try:
+                query = await self._results.get_running_query(query)
+            except QueryError as e:
+                await self._results.handle_query_exception(query, e)
+                return None
+            await self._state.store_query(query)
+            if query.status.status == AsyncQueryPhase.EXECUTING:
+                return query.to_job_status()
             await self._arq.enqueue("handle_finished_query", query.query_id)
             await self._state.mark_queued_query(query.query_id)
             logger.info("Dispatched finished query to worker")

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -12,6 +12,7 @@ from ..events import Events, TemporaryTableUploadEvent
 from ..exceptions import (
     BackendApiError,
     BackendApiFailedError,
+    QueryError,
     TableUploadWebError,
 )
 from ..models.kafka import (
@@ -77,24 +78,18 @@ class QueryService:
         self._results = result_processor
         self._rate_store = rate_limit_store
         self._gafaelfawr = gafaelfawr_storage
-        self._arq_queue = arq_queue
+        self._arq = arq_queue
         self._events = events
         self._slack_client = slack_client
         self._logger = logger
 
-    async def cancel_query(self, message: JobCancel) -> JobStatus | None:
+    async def cancel_query(self, message: JobCancel) -> None:
         """Cancel a running query.
 
         Parameters
         ----------
         message
             Request to cancel the query.
-
-        Returns
-        -------
-        JobStatus or None
-            New status of job, or `None` if there is no update or if the
-            cancel message is invalid.
         """
         logger = self._logger.bind(
             job_id=message.job_id, username=message.owner
@@ -104,7 +99,7 @@ class QueryService:
         query = await self._state.get_query(query_id)
         if not query:
             logger.warning("Cannot cancel unknown or completed job")
-            return None
+            return
 
         # Cancel the query. If this fails, check to see if it only failed
         # because the job finished and, if so, quietly do nothing and let
@@ -121,29 +116,11 @@ class QueryService:
             try:
                 status = await self._backend.get_query_status(query_id)
                 if status.status != AsyncQueryPhase.EXECUTING:
-                    return None
+                    return
             except BackendApiError:
                 pass
             await report_exception(e, self._slack_client)
             logger.exception("Failed to cancel query", error=str(e))
-            return None
-
-        # Return an appropriate status update for the job's current status.
-        return await self._results.build_query_status(query)
-
-    async def handle_cancel(self, message: JobCancel) -> None:
-        """Handle an incoming cancel request.
-
-        Cancel the running query if necessary and publish any status update.
-
-        Parameters
-        ----------
-        message
-            Request to cancel the query.
-        """
-        status = await self.cancel_query(message)
-        if status:
-            await self._results.publish_status(status)
 
     async def handle_query(
         self, job: JobRun, kafka_start: datetime | None
@@ -163,7 +140,7 @@ class QueryService:
             Time at which the Kafka message for the job was queued.
         """
         if job.upload_tables:
-            await self._arq_queue.enqueue(
+            await self._arq.enqueue(
                 "handle_upload_job",
                 job,
                 kafka_start,
@@ -230,10 +207,51 @@ class QueryService:
             await self._rate_store.end_query(job.owner)
             raise
 
-        # Update the query status and return the status message to send.
-        return await self._results.build_query_status(
-            started_query, initial=True
-        )
+        # Construct an initial status update to post to Kafka.
+        return await self._build_initial_status(started_query, logger)
+
+    async def _build_initial_status(
+        self, started_query: StartedQuery, logger: BoundLogger
+    ) -> JobStatus:
+        """Store the running query and construct the initial status.
+
+        Store the running query in Redis for further tracking and construct
+        the initial status update to return to Kafka.
+
+        Parameters
+        ----------
+        started_query
+            Started query.
+        logger
+            Logger to use.
+
+        Returns
+        -------
+        JobStatus
+            Initial status update to send to Kafka.
+        """
+        try:
+            query = await self._results.get_running_query(started_query)
+        except QueryError as e:
+            await self._results.delete_query_data(started_query)
+            job = started_query.job
+            error = e.to_job_error()
+            return JobStatus.from_error(job, error, started_query.query_id)
+
+        # If the query has already completed successfully, immediately
+        # dispatch it to the result worker and and send an executing status.
+        # Otherwise, let the result service build the status, which handles
+        # executing, aborted, and failed queries.
+        if query.status.status == AsyncQueryPhase.COMPLETED:
+            query.result_queued = True
+            await self._state.store_query(query)
+            await self._arq.enqueue("handle_finished_query", query.query_id)
+            logger.info("Dispatched immediately completed query to worker")
+            return query.to_job_status()
+        else:
+            if query.status.status == AsyncQueryPhase.EXECUTING:
+                await self._state.store_query(query)
+            return await self._results.process_query(query)
 
     def _build_invalid_request_status(
         self, job: JobRun, message: str

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -96,90 +96,24 @@ class ResultProcessor(ABC):
         self._slack_client = slack_client
         self._logger = logger
 
-    def build_executing_status(self, query: RunningQuery) -> JobStatus:
-        """Build the status for a query that's still executing.
+    async def delete_query_data(self, query: StartedQuery) -> None:
+        """Delete stored information for the query.
+
+        Remove the query from the Kafka bridge state storage and delete
+        any uploaded temporary tables.
 
         Parameters
         ----------
         query
-            Metadata about the query.
-
-        Returns
-        -------
-        JobStatus
-            Job status to report to Kafka.
-        """
-        self._logger.debug("Query is executing", **query.to_logging_context())
-        return query.to_job_status()
-
-    async def build_query_status(
-        self, query: StartedQuery, *, initial: bool = False
-    ) -> JobStatus:
-        """Retrieve query status and convert it to a job status update.
-
-        If the query has already completed, retrieve the results if successful
-        and return an appropriate final status. Otherwise, return a status
-        message indicating that the job has started executing.
-
-        Parameters
-        ----------
-        query
-            Metadata about the query without the Qserv status.
-        initial
-            Whether this is the first status call immediately after starting
-            the job.
-
-        Returns
-        -------
-        JobStatus
-            Job status to report to Kafka.
+            Query metadata.
+        logger
+            Logger to use.
         """
         logger = self._logger.bind(**query.to_logging_context())
-
-        # Get the current query status.
-        try:
-            status = await self._backend.get_query_status(query.query_id)
-        except BackendApiError as e:
-            await report_exception(e, slack_client=self._slack_client)
-            logger.exception("Unable to get job status", error=str(e))
-            await self._delete_query_data(query, logger)
-            return JobStatus.from_error(
-                query.job, e.to_job_error(), query.query_id
-            )
-        full_query = RunningQuery.from_started_query(query, status)
-        logger = self._logger.bind(**full_query.to_logging_context())
-
-        # Based on the status, process the results.
-        match status.status:
-            case AsyncQueryPhase.ABORTED:
-                result = await self._build_aborted_status(full_query)
-            case AsyncQueryPhase.EXECUTING:
-                if initial:
-                    await self._state.store_query(full_query)
-                else:
-                    await self._state.update_status(query.query_id, status)
-                return self.build_executing_status(full_query)
-            case AsyncQueryPhase.COMPLETED if initial:
-                # The query was already completed on the first check.
-                # Dispatch to the worker pool and report the job as
-                # still executing.
-                full_query.result_queued = True
-                await self._state.store_query(full_query)
-                await self._arq.enqueue(
-                    "handle_finished_query", query.query_id
-                )
-                logger.info("Dispatched immediately completed query to worker")
-                return self.build_executing_status(full_query)
-            case AsyncQueryPhase.COMPLETED:
-                result = await self._build_completed_status(full_query)
-            case AsyncQueryPhase.FAILED:
-                result = await self._build_failed_status(full_query)
-
-        # Query was completed, either successfully or unsuccessfully. Delete
-        # any state storage needed for it, update rate limits, and return the
-        # resulting status.
-        await self._delete_query_data(query, logger)
-        return result
+        logger.debug("Cleaning up query data")
+        await self._state.delete_query(query.query_id)
+        await self._rate_store.end_query(query.job.owner)
+        await self.delete_uploaded_databases(query.job)
 
     async def delete_uploaded_databases(
         self,
@@ -217,27 +151,76 @@ class ResultProcessor(ABC):
                     database_name=database,
                 )
 
-    async def handle_completed_query(self, query: RunningQuery) -> JobStatus:
-        """Process a completed query.
-
-        This method should only be called when the caller already knows the
-        backend has indicated that the query has completed, such as from a
-        result processing worker.
+    async def get_running_query(self, query: StartedQuery) -> RunningQuery:
+        """Retrieve the query status and construct a running query record.
 
         Parameters
         ----------
         query
-            Query whose results should be processed.
+            Metadata about the query, possibly without the backend status.
+
+        Returns
+        -------
+        RunningQuery
+            Query enhanced with backend status.
+        """
+        try:
+            status = await self._backend.get_query_status(query.query_id)
+        except BackendApiError as e:
+            await report_exception(e, slack_client=self._slack_client)
+            logger = self._logger.bind(**query.to_logging_context())
+            logger.exception("Unable to get job status", error=str(e))
+            raise
+        return RunningQuery.from_started_query(query, status)
+
+    async def handle_query_exception(
+        self, query: StartedQuery, exc: QueryError
+    ) -> None:
+        """Handle a query that started but failed due to an exception.
+
+        Cleans up the job and publishes an appropriate status message to
+        Kafka.
+
+        Parameters
+        ----------
+        query
+            Failed query.
+        exc
+            Exception provoking the query failure.
+        """
+        error = exc.to_job_error()
+        status = JobStatus.from_error(query.job, error, query.query_id)
+        await self.publish_status(status)
+        await self.delete_query_data(query)
+
+    async def process_query(self, query: RunningQuery) -> JobStatus:
+        """Convert the query status to a Kafka update.
+
+        If the query has already completed, retrieve the results if successful
+        and return an appropriate final status. Otherwise, return a status
+        message indicating that the job is executing.
+
+        Parameters
+        ----------
+        query
+            Metadata about the query without the Qserv status.
 
         Returns
         -------
         JobStatus
-            Job status message to send to Kafka.
+            Job status to report to Kafka.
         """
-        logger = self._logger.bind(**query.to_logging_context())
-        status = await self._build_completed_status(query)
-        await self._delete_query_data(query, logger)
-        return status
+        match query.status.status:
+            case AsyncQueryPhase.ABORTED:
+                return await self._build_aborted_status(query)
+            case AsyncQueryPhase.EXECUTING:
+                logger = self._logger.bind(**query.to_logging_context())
+                logger.debug("Query is executing")
+                return query.to_job_status()
+            case AsyncQueryPhase.COMPLETED:
+                return await self._build_completed_status(query)
+            case AsyncQueryPhase.FAILED:
+                return await self._build_failed_status(query)
 
     async def publish_status(self, status: JobStatus) -> None:
         """Publish a status update to Kafka.
@@ -461,29 +444,6 @@ class ResultProcessor(ABC):
         await self._events.query_failure.publish(event)
         job_error = JobError(code=code, message=error)
         return query.to_job_status(ExecutionPhase.ERROR, job_error)
-
-    async def _delete_query_data(
-        self, query: StartedQuery, logger: BoundLogger
-    ) -> None:
-        """Delete stored information for the query.
-
-        Remove the query from the Kafka bridge state storage and delete
-        any uploaded temporary tables.
-
-        Parameters
-        ----------
-        query
-            Query metadata.
-        logger
-            Logger to use.
-        """
-        logger.debug(
-            "Cleaning up query data",
-            upload_table_count=len(query.job.upload_tables),
-        )
-        await self._state.delete_query(query.query_id)
-        await self._rate_store.end_query(query.job.owner)
-        await self.delete_uploaded_databases(query.job)
 
     async def _upload_results(self, query: RunningQuery) -> UploadStats:
         """Retrieve and upload the results.

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -77,31 +77,32 @@ class QueryStateStore:
         ----------
         query_id
             Backend query ID.
+
+        Notes
+        -----
+        This is currently highly inefficient since it rewrites the whole Redis
+        object, which for queries that may contain large numbers of result
+        fields can be fairly large. So far, it hasn't seemed to matter, but
+        look here if you are seeing Redis performance issues.
         """
         query = await self.get_query(query_id)
         if query:
             query.result_queued = True
-            lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
-            await self._storage.store(
-                query_id, query, lifetime, exclude_defaults=True
-            )
+            await self.store_query(query)
 
-    async def store_query(
-        self, query: RunningQuery, *, result_queued: bool = False
-    ) -> None:
+    async def store_query(self, query: RunningQuery) -> None:
         """Add or update a record for an in-progress query.
 
         Parameters
         ----------
         query
             Query to store.
-        result_queued
-            Whether this query has been dispatched to arq for result
-            processing.
         """
-        lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
         await self._storage.store(
-            query.query_id, query, lifetime, exclude_defaults=True
+            query.query_id,
+            query,
+            lifetime=int(MAXIMUM_QUERY_LIFETIME.total_seconds()),
+            exclude_defaults=True,
         )
 
     async def update_status(self, query_id: str, status: QueryStatus) -> None:
@@ -113,12 +114,16 @@ class QueryStateStore:
             Backend query ID.
         status
             Backend query status.
+
+        Notes
+        -----
+        This is currently highly inefficient since it rewrites the whole Redis
+        object, which for queries that may contain large numbers of result
+        fields can be fairly large. So far, it hasn't seemed to matter, but
+        look here if you are seeing Redis performance issues.
         """
         query = await self.get_query(query_id)
         if query:
             query.result_queued = False
             query.status.update_from(status.to_process_status())
-            lifetime = int(MAXIMUM_QUERY_LIFETIME.total_seconds())
-            await self._storage.store(
-                query_id, query, lifetime, exclude_defaults=True
-            )
+            await self.store_query(query)

--- a/src/qservkafka/workers/functions/results.py
+++ b/src/qservkafka/workers/functions/results.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 from structlog.stdlib import BoundLogger
-from vo_models.uws.types import ExecutionPhase
 
 from ...factory import Factory
 
@@ -27,13 +26,6 @@ async def handle_finished_query(ctx: dict[Any, Any], query_id: str) -> None:
         logger.warning("Query state not found, skipping", query_id=query_id)
         return
     processor = factory.create_result_processor()
-    status = await processor.build_query_status(query)
-    if status.status == ExecutionPhase.EXECUTING:
-        logger.warning(
-            "Apparently completed job still executing",
-            job_id=query.job.job_id,
-            qserv_id=str(query.query_id),
-            username=query.job.owner,
-            status=status.model_dump(mode="json", exclude_none=True),
-        )
+    status = await processor.process_query(query)
     await processor.publish_status(status)
+    await processor.delete_query_data(query)

--- a/tests/data/status/simple-immediate.json
+++ b/tests/data/status/simple-immediate.json
@@ -1,0 +1,17 @@
+{
+  "executionID": "1",
+  "jobID": "uws123",
+  "metadata": {
+    "database": "dp1",
+    "query": "SELECT TOP 10 * FROM table"
+  },
+  "queryInfo": {
+    "progress": {
+      "completedChunks": 10,
+      "totalChunks": 10
+    },
+    "startTime": "<ANY>"
+  },
+  "status": "EXECUTING",
+  "timestamp": "<ANY>"
+}

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -1,7 +1,7 @@
 """Test the Qserv Kafka bridge with a real Kafka server."""
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from asgi_lifespan import LifespanManager
@@ -30,6 +30,7 @@ from ..support.arq import (
     wait_for_dispatch,
 )
 from ..support.data import QservKafkaData
+from ..support.datetime import assert_approximately_now
 from ..support.kafka import KafkaTestManager
 from ..support.qserv import MockQserv
 
@@ -235,9 +236,6 @@ async def test_qserv_error(
     processing when the API request failed.
     """
     async with LifespanManager(app):
-        factory = context_dependency.create_factory()
-        arq_worker = create_arq_worker(factory._context)
-
         await kafka_manager.start_query("jobs/simple")
         status = await kafka_manager.wait_for_status("status/simple-started")
         assert status.query_info
@@ -251,10 +249,6 @@ async def test_qserv_error(
             last_update=datetime.now(tz=UTC).replace(microsecond=0),
         )
         await mock_qserv.update_status(1, qserv_status)
-        await wait_for_dispatch(factory, 1)
-
-        # Run the background tsk queue.
-        assert await arq_worker.run_check() == 1
         status = await kafka_manager.wait_for_status("status/simple-error")
 
     # Ensure all query state has been deleted.
@@ -274,24 +268,16 @@ async def test_missing_executing(
 ) -> None:
     """Test queries that are not in the process list but still executing."""
     async with LifespanManager(app):
-        factory = context_dependency.create_factory()
         await kafka_manager.start_query("jobs/data")
         await kafka_manager.wait_for_status("status/data-started")
 
-        # Remove the query from the running query list. It should be
-        # dispatched to the result worker.
+        # Remove the query from the running query list. This should generate
+        # another status update from the monitor task.
         await mock_qserv.remove_running_query(1)
-        await wait_for_dispatch(factory, 1)
+        await kafka_manager.wait_for_status("status/data-started")
 
-    # Run the backend worker. It should process the job and send the same
-    # status update we already sent (since nothing has changed).
-    arq_worker = create_arq_worker()
-    assert await arq_worker.run_check() == 1
-    await kafka_manager.wait_for_status("status/data-started")
-
-    # The query should still be active and should no longer be marked as
-    # dispatched, so it will be checked again the next time through the
-    # monitor loop.
+    # The query should still be active and should not be marked as dispatched,
+    # so it will be checked again the next time through the monitor loop.
     redis_client = redis.get_client()
     raw_query = redis_client.get("query:1")
     assert raw_query
@@ -301,6 +287,9 @@ async def test_missing_executing(
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
+)
 async def test_cancel(
     *,
     data: QservKafkaData,
@@ -310,6 +299,9 @@ async def test_cancel(
     redis: RedisContainer,
 ) -> None:
     async with LifespanManager(app):
+        factory = context_dependency.create_factory()
+        arq_worker = create_arq_worker(factory._context)
+
         await kafka_manager.start_query("jobs/simple")
         status = await kafka_manager.wait_for_status("status/simple-started")
         assert status.query_info
@@ -319,7 +311,12 @@ async def test_cancel(
         cancel = data.read_json("cancel/simple")
         await kafka_broker.publish(cancel, config.job_cancel_topic)
 
+        await wait_for_dispatch(factory, 1)
+        assert await arq_worker.run_check() == 1
+
         status = await kafka_manager.wait_for_status("status/simple-aborted")
+        finish = datetime.now(tz=UTC)
+        assert_approximately_now(status.timestamp)
         assert status.query_info
         assert status.query_info.start_time == start_time
         assert status.query_info.end_time
@@ -328,6 +325,13 @@ async def test_cancel(
     # Ensure all query state has been deleted.
     redis_client = redis.get_client()
     assert set(redis_client.scan_iter("query:*")) == set()
+
+    # Check that the correct metrics event was sent.
+    assert isinstance(factory.events.query_abort, MockEventPublisher)
+    events = factory.events.query_abort.published
+    assert len(events) == 1
+    data.assert_pydantic_matches(events[0], "events/abort")
+    assert timedelta(seconds=0) < events[0].elapsed <= (finish - start_time)
 
 
 @pytest.mark.asyncio

--- a/tests/services/errors_test.py
+++ b/tests/services/errors_test.py
@@ -141,16 +141,13 @@ async def test_start_invalid(
 async def test_sql_failure(
     data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
 ) -> None:
-    query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     job = data.read_pydantic(JobRun, "jobs/data")
 
     mock_qserv.set_immediate_success(job)
     results_sql = "SELECT * FROM nonexistent"
     with patch.object(qserv, "_query_results_sql", return_value=results_sql):
-        status = await start_and_complete_immediate(
-            query_service, factory, job
-        )
+        status = await start_and_complete_immediate(factory, job)
     data.assert_job_status_matches(status, "status/error-sql")
     assert status.error
     assert "SQL query error: " in status.error.message
@@ -171,14 +168,13 @@ async def test_upload_timeout(
 
     This should also cover a timeout in retrieving the data from SQL.
     """
-    query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     job = data.read_pydantic(JobRun, "jobs/data")
 
     mock_qserv.set_immediate_success(job)
     mock_qserv.set_upload_delay(timedelta(seconds=2))
     monkeypatch.setattr(config, "result_timeout", timedelta(seconds=1))
-    status = await start_and_complete_immediate(query_service, factory, job)
+    status = await start_and_complete_immediate(factory, job)
     data.assert_job_status_matches(status, "status/error-upload-timeout")
     expected = "Timed out retrieving and uploading results after "
     assert status.error
@@ -190,8 +186,10 @@ async def test_upload_timeout(
 
 @pytest.mark.asyncio
 async def test_cancel_unknown(data: QservKafkaData, factory: Factory) -> None:
-    """Test canceling an unknown job."""
+    """Test canceling an unknown job.
+
+    This should quietly do nothing.
+    """
     query_service = factory.create_query_service()
     cancel = data.read_pydantic(JobCancel, "cancel/simple")
-
-    assert await query_service.cancel_query(cancel) is None
+    await query_service.cancel_query(cancel)

--- a/tests/services/leak_test.py
+++ b/tests/services/leak_test.py
@@ -56,13 +56,12 @@ async def test_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test for memory leaks in the immediate job processing flow."""
-    query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
     job = data.read_pydantic(JobRun, "jobs/data")
     mock_qserv.set_immediate_success(job)
 
     # Run one query first to set up the various internal Python caches.
-    status = await start_and_complete_immediate(query_service, factory, job)
+    status = await start_and_complete_immediate(factory, job)
     data.assert_job_status_matches(status, "status/data-completed")
 
     # Start tracing memory.
@@ -72,9 +71,7 @@ async def test_success(
 
     # Run 100 more tasks with memory tracing.
     for i in range(2, 102):
-        status = await start_and_complete_immediate(
-            query_service, factory, job
-        )
+        status = await start_and_complete_immediate(factory, job)
         data.assert_job_status_matches(
             status, "status/data-completed", execution_id=str(i)
         )

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -54,7 +54,7 @@ async def assert_query_successful(
     mock_qserv.set_immediate_success(job)
     kafka_timestamp = datetime.now(tz=UTC) - timedelta(seconds=10)
     result = await start_and_complete_immediate(
-        query_service, factory, job, kafka_start=kafka_timestamp
+        factory, job, kafka_start=kafka_timestamp
     )
     data.assert_job_status_matches(result, status, execution_id=execution_id)
     assert_approximately_now(result.timestamp)
@@ -165,8 +165,10 @@ async def test_immediate(
 async def test_immediate_dispatch(
     data: QservKafkaData, factory: Factory, mock_qserv: MockQserv
 ) -> None:
-    """Test that a job that completed immediately is dispatched to a worker
-    and that the dispatch is not repeated on a later check.
+    """Test correct dispatch of a query that finishes immediately.
+
+    Test that a job that completed immediately is dispatched to a worker,
+    returns an executing status, and properly marked as queued.
     """
     query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
@@ -177,18 +179,10 @@ async def test_immediate_dispatch(
         status = await query_service.start_query(job)
         assert mock.call_args_list == [call("handle_finished_query", "1")]
 
-    assert status.status == ExecutionPhase.EXECUTING
-    assert status.execution_id == "1"
-
+    data.assert_job_status_matches(status, "status/simple-immediate")
     query = await state_store.get_query("1")
     assert query
     assert query.result_queued
-
-    result_processor = factory.create_result_processor()
-    with patch.object(RedisArqQueue, "enqueue") as mock:
-        result = await result_processor.build_query_status(query)
-        assert mock.call_args_list == []
-    data.assert_job_status_matches(result, "status/data-completed")
 
 
 @pytest.mark.asyncio
@@ -230,44 +224,6 @@ async def test_no_delete(
 @pytest.mark.parametrize(
     "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
 )
-async def test_cancel(data: QservKafkaData, factory: Factory) -> None:
-    job = data.read_pydantic(JobRun, "jobs/simple")
-    cancel = data.read_pydantic(JobCancel, "cancel/simple")
-    query_service = factory.create_query_service()
-    state_store = factory.create_query_state_store()
-
-    start_status = await query_service.start_query(job)
-    data.assert_job_status_matches(start_status, "status/simple-started")
-    assert_approximately_now(start_status.timestamp)
-    assert start_status.query_info
-    start_time = start_status.query_info.start_time
-    assert_approximately_now(start_time)
-
-    assert await state_store.get_active_queries() == {"1"}
-
-    now = datetime.now(tz=UTC)
-    cancel_status = await query_service.cancel_query(cancel)
-    assert cancel_status
-    finish = datetime.now(tz=UTC)
-    data.assert_job_status_matches(cancel_status, "status/simple-aborted")
-    assert_approximately_now(cancel_status.timestamp)
-    assert cancel_status.query_info
-    assert cancel_status.query_info.start_time == start_time
-    assert cancel_status.query_info.end_time
-    assert cancel_status.query_info.end_time >= now
-
-    # Check that the correct metrics event was sent.
-    assert isinstance(factory.events.query_abort, MockEventPublisher)
-    events = factory.events.query_abort.published
-    assert len(events) == 1
-    data.assert_pydantic_matches(events[0], "events/abort")
-    assert timedelta(seconds=0) < events[0].elapsed <= (finish - start_time)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_qserv", [False, True], ids=["good", "flaky"], indirect=True
-)
 async def test_cancel_completed(
     *,
     data: QservKafkaData,
@@ -292,8 +248,10 @@ async def test_cancel_completed(
     )
     await mock_qserv.update_status(1, qserv_status)
 
-    # Canceling a completed query should quietly do nothing.
-    assert await query_service.cancel_query(cancel) is None
+    # Canceling a completed query should quietly do nothing. The mock Qserv
+    # returns an error if we try to cancel a completed job, so the lack of a
+    # reported error indicates correct behavior.
+    await query_service.cancel_query(cancel)
     assert isinstance(factory.events.query_abort, MockEventPublisher)
     events = factory.events.query_abort.published
     assert len(events) == 0

--- a/tests/support/qserv.py
+++ b/tests/support/qserv.py
@@ -277,7 +277,7 @@ class MockQserv:
         """
         self._upload_delay = delay
 
-    def cancel(self, request: Request, *, query_id: str) -> Response:
+    async def cancel(self, request: Request, *, query_id: str) -> Response:
         """Cancel a running job.
 
         Parameters
@@ -311,6 +311,7 @@ class MockQserv:
             )
         status.status = QservQueryPhase.ABORTED
         status.last_update = datetime.now(tz=UTC)
+        await self.remove_running_query(int(query_id))
         return Response(200, json={"success": 1}, request=request)
 
     async def delete_results(

--- a/tests/support/query.py
+++ b/tests/support/query.py
@@ -6,13 +6,11 @@ from vo_models.uws.types import ExecutionPhase
 
 from qservkafka.factory import Factory
 from qservkafka.models.kafka import JobRun, JobStatus
-from qservkafka.services.query import QueryService
 
 __all__ = ["start_and_complete_immediate"]
 
 
 async def start_and_complete_immediate(
-    query_service: QueryService,
     factory: Factory,
     job: JobRun,
     *,
@@ -22,13 +20,12 @@ async def start_and_complete_immediate(
 
     Queries found already complete on their first status check are
     dispatched to the result worker, so this also simulates that worker
-    running by calling the result processor directly, just like
-    ``handle_finished_query`` does.
+    running by calling the result processor directly while avoiding the arq
+    queue and workers, since there is no easy way to patch the arq workers to
+    not use Kafka.
 
     Parameters
     ----------
-    query_service
-        Query service to start the job with.
     factory
         Component factory to use.
     job
@@ -41,13 +38,16 @@ async def start_and_complete_immediate(
     JobStatus
         The completed status of the job.
     """
-    initial_status = await query_service.start_query(job, kafka_start)
-    assert initial_status.status == ExecutionPhase.EXECUTING
-    assert initial_status.execution_id
-
+    query_service = factory.create_query_service()
     state_store = factory.create_query_state_store()
-    query = await state_store.get_query(initial_status.execution_id)
+    processor = factory.create_result_processor()
+
+    status = await query_service.start_query(job, kafka_start)
+    assert status.status == ExecutionPhase.EXECUTING
+    assert status.execution_id
+    query = await state_store.get_query(status.execution_id)
     assert query
 
-    result_processor = factory.create_result_processor()
-    return await result_processor.handle_completed_query(query)
+    status = await processor.process_query(query)
+    await processor.delete_query_data(query)
+    return status


### PR DESCRIPTION
Get rid of the confusing `build_query_status` method in favor of cleanly separating retrieving the current backend status and building Kafka status messages from the backend status.

Retrieve the current status of the job in the monitor thread when that status has changed, before dispatching to the result worker. This significantly simplifies the result worker and removes a second query to the backend for query status.

Stop immediately sending a status update for cancelled jobs and let the monitor thread pick up the status change. Cancelling isn't urgent; we don't need to try to get a new status immediately.