### PR TITLE
DM-55758: Parallelize query checking in monitor task

### DIFF
--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -1,5 +1,6 @@
 """Service to monitor the status of running queries."""
 
+import asyncio
 from collections import Counter
 
 from safir.arq import ArqQueue
@@ -8,7 +9,6 @@ from structlog.stdlib import BoundLogger
 from ..config import config
 from ..events import BigQueryExecutingEvent, Events, QservExecutingEvent
 from ..exceptions import QueryError
-from ..models.kafka import JobStatus
 from ..models.query import AsyncQueryPhase, ProcessStatus
 from ..models.state import RunningQuery
 from ..storage.backend import BackendType, DatabaseBackend
@@ -65,7 +65,10 @@ class QueryMonitor:
         if not active_queries:
             return
         running = await self._backend.list_running_queries()
+
+        # Build a list of query check tasks to run.
         queries_executing = 0
+        tasks = []
         for query_id in active_queries:
             query = await self._state.get_query(query_id)
             if not query:
@@ -73,9 +76,10 @@ class QueryMonitor:
             status = running.get(query_id)
             if status and status.status == AsyncQueryPhase.EXECUTING:
                 queries_executing += 1
-            update = await self.check_query(query, status)
-            if update:
-                await self._results.publish_status(update)
+            tasks.append(self.check_query(query, status))
+
+        # Check the status of all the currently running queries in parallel.
+        await asyncio.gather(*tasks)
 
         # Post a metric for how many queries are in flight. This counts only
         # queries that are both still executing and that this bridge instance
@@ -91,11 +95,11 @@ class QueryMonitor:
 
     async def check_query(
         self, query: RunningQuery, status: ProcessStatus | None
-    ) -> JobStatus | None:
+    ) -> None:
         """Check the status of one backend query.
 
         If the query is complete, dispatch it to the result worker. Otherwise,
-        construct a status update for posting to Kafka, if warranted.
+        send a status update for posting to Kafka, if warranted.
 
         Parameters
         ----------
@@ -105,17 +109,11 @@ class QueryMonitor:
             Backend status from the running process list, if the query
             appeared there, or `None` otherwise. If `None`, the job will be
             assumed to be complete.
-
-        Returns
-        -------
-        JobStatus or None
-            The status of the query, for posting to Kafka, or `None` if no
-            update is warranted.
         """
         logger = self._logger.bind(**query.to_logging_context())
         if query.result_queued:
             logger.debug("Skipping already queued query")
-            return None
+            return
 
         # Send updates to executing queries directly from the background
         # monitoring task for faster updates, but dispatch any completed
@@ -123,24 +121,24 @@ class QueryMonitor:
         if status and status.status == AsyncQueryPhase.EXECUTING:
             if not query.status.is_different_than(status):
                 logger.debug("Running query has not changed state")
-                return None
+                return
             query.status.update_from(status)
             await self._state.update_status(query.query_id, query.status)
             logger.debug("Sending status update for running query")
-            return query.to_job_status()
+            await self._results.publish_status(query.to_job_status())
         else:
             try:
                 query = await self._results.get_running_query(query)
             except QueryError as e:
                 await self._results.handle_query_exception(query, e)
-                return None
+                return
             await self._state.store_query(query)
             if query.status.status == AsyncQueryPhase.EXECUTING:
-                return query.to_job_status()
+                await self._results.publish_status(query.to_job_status())
+                return
             await self._arq.enqueue("handle_finished_query", query.query_id)
             await self._state.mark_queued_query(query.query_id)
             logger.info("Dispatched finished query to worker")
-            return None
 
     async def reconcile_rate_limits(self) -> None:
         """Reconcile rate limits against currently running queries."""

--- a/tests/services/monitor_test.py
+++ b/tests/services/monitor_test.py
@@ -51,7 +51,7 @@ async def test_dispatch(
     assert query
     qserv_status = mock_qserv.get_status(1)
     with patch.object(RedisArqQueue, "enqueue") as mock:
-        assert await monitor.check_query(query, status=None) is None
+        await monitor.check_query(query, status=None)
         assert mock.call_args_list == [call("handle_finished_query", "1")]
         mock.reset_mock()
 
@@ -60,7 +60,7 @@ async def test_dispatch(
         # should not dispatch it again.
         query = await state_store.get_query(str(1))
         assert query
-        assert await monitor.check_query(query, status=None) is None
+        await monitor.check_query(query, status=None)
         assert mock.call_args_list == []
 
 


### PR DESCRIPTION
Now that the monitor task is doing a bit more work, since it's responsible for retrieving the query status from Qserv, check all discovered running queries in parallel. This will hopefully reduce the amount that slow Qserv API calls might delay job handling.