### PR TITLE
DM-55758: Shift result deletion to the cleanup step

### DIFF
--- a/changelog.d/20260811_224305_rra_DM_55758.md
+++ b/changelog.d/20260811_224305_rra_DM_55758.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Drop the `immediate` and `delete_elapsed` fields from metrics events. `immediate` is no longer a meaningful concept since all queries are dispatched to result workers, and `delete_elapsed` is no longer tracked as part of query execution since it does not delay returning the results of the query.

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -117,15 +117,6 @@ class QuerySuccessEvent(BaseQueryEvent):
         ),
     )
 
-    delete_elapsed: timedelta | None = Field(
-        None,
-        title="Job deletion time",
-        description=(
-            "How long it took to delete the query from the backend after"
-            " successful completion"
-        ),
-    )
-
     rows: int = Field(
         ..., title="Row count", description="Number of rows in the output"
     )
@@ -176,8 +167,6 @@ class QuerySuccessEvent(BaseQueryEvent):
             result["kafka_elapsed"] = self._to_seconds(self.kafka_elapsed)
         result["result_elapsed"] = self._to_seconds(self.result_elapsed)
         result["submit_elapsed"] = self._to_seconds(self.submit_elapsed)
-        if self.delete_elapsed:
-            result["delete_elapsed"] = self._to_seconds(self.delete_elapsed)
         return result
 
     @staticmethod

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -8,7 +8,7 @@ from safir.datetime import format_datetime_for_logging
 from vo_models.uws.types import ExecutionPhase
 
 from .kafka import JobError, JobQueryInfo, JobResultInfo, JobRun, JobStatus
-from .query import QueryStatus
+from .query import AsyncQueryPhase, QueryStatus
 from .votable import UploadStats
 
 __all__ = [
@@ -68,6 +68,10 @@ class StartedQuery(Query):
             created=datetime.now(tz=UTC),
             job=query.job,
         )
+
+    def has_results(self) -> bool:
+        """Whether this query has results that may need to be deleted."""
+        return False
 
     @override
     def to_logging_context(self) -> dict[str, str | float]:
@@ -137,6 +141,11 @@ class RunningQuery(StartedQuery):
             status=status,
             result_queued=False,
         )
+
+    @override
+    def has_results(self) -> bool:
+        """Whether this query has results that may need to be deleted."""
+        return self.status.status == AsyncQueryPhase.COMPLETED
 
     def to_completed_job_status(self, stats: UploadStats) -> JobStatus:
         """Construct a Kafka job status message for a completed query."""

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -111,9 +111,20 @@ class ResultProcessor(ABC):
         """
         logger = self._logger.bind(**query.to_logging_context())
         logger.debug("Cleaning up query data")
-        await self._state.delete_query(query.query_id)
+
+        # Remove internal tracking. Everything after this point will not be
+        # retried on failure, just orphaned.
         await self._rate_store.end_query(query.job.owner)
+        await self._state.delete_query(query.query_id)
+
+        # Delete the uploaded tables and the results if configured to do so.
         await self.delete_uploaded_databases(query.job)
+        if query.has_results() and config.qserv_delete_queries:
+            try:
+                await self._backend.delete_result(query.query_id)
+            except BackendApiError as e:
+                await report_exception(e, slack_client=self._slack_client)
+                logger.exception("Cannot delete results")
 
     async def delete_uploaded_databases(
         self,
@@ -245,7 +256,6 @@ class ResultProcessor(ABC):
         elapsed: timedelta,
         backend_elapsed: timedelta,
         backend_rate: float | None,
-        delete_elapsed: timedelta | None,
     ) -> QuerySuccessEvent:
         """Publish backend-specific success event.
 
@@ -261,8 +271,6 @@ class ResultProcessor(ABC):
             Time spent in backend.
         backend_rate
             Backend processing rate (bytes/sec).
-        delete_elapsed
-            Time spent deleting results.
 
         Returns
         -------
@@ -323,19 +331,6 @@ class ResultProcessor(ABC):
         except QueryError as e:
             return await self._build_exception_status(query, e)
 
-        # Delete the results if configured to do so.
-        delete_elapsed = None
-        if config.qserv_delete_queries:
-            delete_start = datetime.now(tz=UTC)
-            try:
-                await self._backend.delete_result(query.query_id)
-                delete_elapsed = datetime.now(tz=UTC) - delete_start
-            except BackendApiError as e:
-                delete_elapsed = None
-                await report_exception(e, slack_client=self._slack_client)
-                logger.exception("Cannot delete results")
-            delete_elapsed = datetime.now(tz=UTC) - delete_start
-
         # Send a metrics event for the job completion and log it.
         now = datetime.now(tz=UTC)
         backend_end = query.status.last_update or now
@@ -352,7 +347,6 @@ class ResultProcessor(ABC):
             elapsed=elapsed,
             backend_elapsed=backend_elapsed,
             backend_rate=backend_rate,
-            delete_elapsed=delete_elapsed,
         )
         logger.info(
             "Job complete and results uploaded", **event.to_logging_context()
@@ -559,7 +553,6 @@ class QservResultProcessor(ResultProcessor):
         elapsed: timedelta,
         backend_elapsed: timedelta,
         backend_rate: float | None,
-        delete_elapsed: timedelta | None,
     ) -> QservSuccessEvent:
         event = QservSuccessEvent(
             job_id=query.job.job_id,
@@ -569,7 +562,6 @@ class QservResultProcessor(ResultProcessor):
             qserv_elapsed=backend_elapsed,
             result_elapsed=stats.elapsed,
             submit_elapsed=query.created - query.start,
-            delete_elapsed=delete_elapsed,
             rows=stats.rows,
             qserv_size=query.status.collected_bytes,
             encoded_size=stats.data_bytes,
@@ -603,7 +595,6 @@ class BigQueryResultProcessor(ResultProcessor):
         elapsed: timedelta,
         backend_elapsed: timedelta,
         backend_rate: float | None,
-        delete_elapsed: timedelta | None,
     ) -> BigQuerySuccessEvent:
         event = BigQuerySuccessEvent(
             job_id=query.job.job_id,
@@ -613,7 +604,6 @@ class BigQueryResultProcessor(ResultProcessor):
             bigquery_elapsed=backend_elapsed,
             result_elapsed=stats.elapsed,
             submit_elapsed=query.created - query.start,
-            delete_elapsed=delete_elapsed,
             rows=stats.rows,
             bigquery_size=query.status.collected_bytes,
             bigquery_rate=backend_rate,

--- a/tests/data/events/success-kafka.json
+++ b/tests/data/events/success-kafka.json
@@ -1,5 +1,4 @@
 {
-  "delete_elapsed": "<ANY>",
   "elapsed": "<ANY>",
   "encoded_size": 244,
   "job_id": "uws123",

--- a/tests/data/events/success-no-delete.json
+++ b/tests/data/events/success-no-delete.json
@@ -1,5 +1,4 @@
 {
-  "delete_elapsed": null,
   "elapsed": "<ANY>",
   "encoded_size": 244,
   "job_id": "uws123",

--- a/tests/data/events/success-upload.json
+++ b/tests/data/events/success-upload.json
@@ -1,5 +1,4 @@
 {
-  "delete_elapsed": "<ANY>",
   "elapsed": "<ANY>",
   "encoded_size": 244,
   "job_id": "uws123",

--- a/tests/data/events/success.json
+++ b/tests/data/events/success.json
@@ -1,5 +1,4 @@
 {
-  "delete_elapsed": "<ANY>",
   "elapsed": "<ANY>",
   "encoded_size": 244,
   "job_id": "uws123",

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -122,12 +122,7 @@ async def test_immediate(
         assert timestamp <= elapsed + timedelta(seconds=10)
 
     # These time fields shouldn't include the Kafka delay.
-    for field in (
-        "qserv_elapsed",
-        "result_elapsed",
-        "submit_elapsed",
-        "delete_elapsed",
-    ):
+    for field in ("qserv_elapsed", "result_elapsed", "submit_elapsed"):
         assert timedelta(seconds=0) <= getattr(event, field) <= elapsed
 
     # Check the calculated rates.


### PR DESCRIPTION
Rather than deleting query results from the backend inline with result processing, move query deletion to query data cleanup alongside deleting uploaded tables. This means query results for the user aren't blocked on deleting the query from Qserv.

Remove `delete_elapsed` from the metrics, since it is no longer a contributor to the timing of a query.