### PR TITLE
DM-55758: Add to_logging_context for JobCancel

### DIFF
--- a/src/qservkafka/handlers/kafka.py
+++ b/src/qservkafka/handlers/kafka.py
@@ -1,10 +1,4 @@
-"""Kafka router and consumers.
-
-The `kafka_router` symbol must be imported from this module, not from its true
-source at `~qservkafka.kafkarouters.kafka_router`, to ensure that the router
-is properly configured with its subscribers and publishers. Otherwise, the
-router will have no subscribers and no publishers and will thus do nothing.
-"""
+"""Kafka message handlers."""
 
 import asyncio
 from typing import Annotated

--- a/src/qservkafka/models/kafka.py
+++ b/src/qservkafka/models/kafka.py
@@ -1,4 +1,9 @@
-"""Models for Kafka messages."""
+"""Models for Kafka messages.
+
+The models starting with ``Job`` are used to serialize and deserialize Kafka
+messages. Internally, they are converted or wrapped in models starting with
+``Query``.
+"""
 
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
@@ -90,6 +95,14 @@ class JobCancel(BaseModel):
             validation_alias="ownerID",
         ),
     ]
+
+    def to_logging_context(self) -> dict[str, Any]:
+        """Convert job status details to a logging context."""
+        return {
+            "job_id": self.job_id,
+            "username": self.owner,
+            "backend_id": self.execution_id,
+        }
 
 
 class JobResultEnvelope(BaseModel):

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -83,33 +83,25 @@ class QueryService:
         self._slack_client = slack_client
         self._logger = logger
 
-    async def cancel_query(self, message: JobCancel) -> None:
+    async def cancel_query(self, cancel: JobCancel) -> None:
         """Cancel a running query.
 
         Parameters
         ----------
-        message
+        cancel
             Request to cancel the query.
         """
-        logger = self._logger.bind(
-            job_id=message.job_id, username=message.owner
-        )
-        query_id = message.execution_id
-        logger = logger.bind(backend_id=query_id)
+        logger = self._logger.bind(**cancel.to_logging_context())
+        query_id = cancel.execution_id
         query = await self._state.get_query(query_id)
         if not query:
-            logger.warning("Cannot cancel unknown or completed job")
+            logger.info("Ignoring cancel of unknown or completed job")
             return
 
         # Cancel the query. If this fails, check to see if it only failed
-        # because the job finished and, if so, quietly do nothing and let
-        # normal result processing pick up the completion since it's too late
-        # to cancel.
-        #
-        # There's not much we can do with exceptions other than log them,
-        # since we don't have a way of returning a cancelation error to the
-        # TAP server, so we send a status update matching the last known
-        # status in that case.
+        # because the job finished and, if so, quietly do nothing. Otherwise,
+        # log an exception, which is the best we can do since we don't have a
+        # way of returning a cancelation error to the TAP server.
         try:
             await self._backend.cancel_query(query_id)
         except BackendApiError as e:


### PR DESCRIPTION
Following the changes for `JobRun`, add a `to_logging_context` method to `JobCancel` to simplify setting up logging in the query service.

Remove an obsolete comment in the Kafka handlers module.