### PR TITLE
DM-55758: Refactor event handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ warn_unused_ignores = true
 [tool.pydantic-mypy]
 init_forbid_extra = true
 init_typed = true
-warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
 [tool.pytest]

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -1,6 +1,7 @@
 """Application settings."""
 
 from datetime import timedelta
+from enum import StrEnum
 from typing import Any, Self
 
 from arq.connections import RedisSettings
@@ -22,9 +23,24 @@ from safir.logging import LogLevel, Profile
 from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 from safir.pydantic import EnvRedisDsn, HumanTimedelta
 
-from .storage.backend import BackendType
+__all__ = [
+    "BackendType",
+    "Config",
+    "SlackConfig",
+    "config",
+]
 
-__all__ = ["Config", "config"]
+
+class BackendType(StrEnum):
+    """Supported database backend types.
+
+    These values use canonical capitalization (Qserv, BigQuery). Metrics
+    events use separate hardcoded names (qserv_success, bigquery_success)
+    so changes here don't affect metrics dashboards.
+    """
+
+    QSERV = "Qserv"
+    BIGQUERY = "BigQuery"
 
 
 class SlackConfig(BaseSettings):

--- a/src/qservkafka/events.py
+++ b/src/qservkafka/events.py
@@ -4,25 +4,24 @@ from datetime import timedelta
 from enum import StrEnum
 from typing import Any, override
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from safir.dependencies.metrics import EventMaker
-from safir.metrics import EventManager, EventPayload
+from safir.metrics import EventManager, EventPayload, EventPublisher
 
+from .config import BackendType, config
 from .models.kafka import JobErrorCode
 
 __all__ = [
-    "BaseExecutingEvent",
-    "BaseFailureEvent",
     "BaseQueryEvent",
-    "BigQueryExecutingEvent",
-    "BigQueryFailureEvent",
+    "BigQueryApiFailureEvent",
     "BigQuerySuccessEvent",
     "Events",
-    "QservExecutingEvent",
-    "QservFailureEvent",
+    "QservApiFailureEvent",
     "QservProtocol",
     "QservSuccessEvent",
     "QueryAbortEvent",
+    "QueryApiFailureEvent",
+    "QueryExecutingEvent",
     "QueryFailureEvent",
     "QuerySuccessEvent",
     "TemporaryTableUploadEvent",
@@ -39,15 +38,11 @@ class QservProtocol(StrEnum):
     SQL = "SQL"
 
 
-class BaseFailureEvent(EventPayload):
-    """Base class for backend-specific failure events.
-
-    Different backends (Qserv, BigQuery, etc.) inherit from this to create
-    backend specific failure events with appropriate fields.
-    """
+class QueryApiFailureEvent(EventPayload):
+    """Base class for retriable backend-specific failure events."""
 
 
-class QservFailureEvent(BaseFailureEvent):
+class QservApiFailureEvent(QueryApiFailureEvent):
     """Unexpected failure sending a Qserv API request.
 
     This event will be logged for each low-level API failure (either HTTP or
@@ -57,7 +52,7 @@ class QservFailureEvent(BaseFailureEvent):
     protocol: QservProtocol = Field(..., title="Protocol of Qserv API")
 
 
-class BigQueryFailureEvent(BaseFailureEvent):
+class BigQueryApiFailureEvent(QueryApiFailureEvent):
     """Unexpected failure sending a BigQuery API request.
 
     This event will be logged for each low-level API failure to the BigQuery
@@ -81,8 +76,9 @@ class BaseQueryEvent(EventPayload):
 class QuerySuccessEvent(BaseQueryEvent):
     """Base class for backend-specific query success events.
 
-    Different backends (Qserv, BigQuery, etc.) inherit from this to create
-    backend-specific success events with appropriate metrics.
+    We unfortunately decided to use different field names for the backend
+    size, elapsed, and rate metrics, so those are provided by subclasses that
+    use the same validation alias but serialize with different field names.
     """
 
     elapsed: timedelta = Field(
@@ -182,12 +178,14 @@ class QservSuccessEvent(QuerySuccessEvent):
         ...,
         title="Qserv processing time",
         description="How long it took for Qserv to process the query",
+        validation_alias=AliasChoices("qserv_elapsed", "backend_elapsed"),
     )
 
     qserv_size: int = Field(
         ...,
         title="Data size from Qserv",
         description="Result size reported by Qserv in bytes",
+        validation_alias=AliasChoices("qserv_size", "backend_size"),
     )
 
     qserv_rate: float | None = Field(
@@ -197,6 +195,7 @@ class QservSuccessEvent(QuerySuccessEvent):
             "Qserv data bytes per second for query, or null if the"
             " query completed too quickly to determine a meaningful rate"
         ),
+        validation_alias=AliasChoices("qserv_rate", "backend_rate"),
     )
 
     @override
@@ -214,12 +213,14 @@ class BigQuerySuccessEvent(QuerySuccessEvent):
         ...,
         title="BigQuery processing time",
         description="How long it took for BigQuery to process the query",
+        validation_alias=AliasChoices("bigquery_elapsed", "backend_elapsed"),
     )
 
     bigquery_size: int = Field(
         ...,
         title="Data size from BigQuery",
         description="Result size reported by BigQuery in bytes",
+        validation_alias=AliasChoices("bigquery_size", "backend_size"),
     )
 
     bigquery_rate: float | None = Field(
@@ -229,6 +230,7 @@ class BigQuerySuccessEvent(QuerySuccessEvent):
             "BigQuery data bytes per second for query, or null if the"
             " query completed too quickly to determine a meaningful rate"
         ),
+        validation_alias=AliasChoices("bigquery_rate", "backend_rate"),
     )
 
     @override
@@ -252,6 +254,12 @@ class QueryAbortEvent(BaseQueryEvent):
     )
 
 
+class QueryExecutingEvent(EventPayload):
+    """Base for gauge metrics for queries in progress in the backend."""
+
+    count: int = Field(..., title="Queries in progress")
+
+
 class QueryFailureEvent(BaseQueryEvent):
     """Query failed for some reason.
 
@@ -269,28 +277,6 @@ class QueryFailureEvent(BaseQueryEvent):
             " query to the eventual failure of the query"
         ),
     )
-
-
-class BaseExecutingEvent(EventPayload):
-    """Base for gauge metrics for queries in progress in the backend."""
-
-    count: int = Field(..., title="Queries in progress")
-
-
-class BigQueryExecutingEvent(BaseExecutingEvent):
-    """Queries in progress in BigQuery.
-
-    This will be logged every time BigQuery is asked for its list of running
-    queries to see if any have finished.
-    """
-
-
-class QservExecutingEvent(BaseExecutingEvent):
-    """Queries in progress in Qserv.
-
-    This will be logged every time Qserv is asked for its list of running
-    queries to see if any have finished.
-    """
 
 
 class TemporaryTableUploadEvent(BaseQueryEvent):
@@ -313,50 +299,60 @@ class TemporaryTableUploadEvent(BaseQueryEvent):
 
 
 class Events(EventMaker):
-    """Event publishers for all possible events, used by workers and frontend.
+    """Event publishers for all possible events.
+
+    We made some unfortunate historical decisions in the naming of the various
+    metrics, so this class does some rewriting to preserve those metric names
+    while exposing the same publisher names to callers.
 
     Attributes
     ----------
-    qserv_failure
-        Qserv API call failed with a protocol error.
-    bigquery_failure
-        BigQuery API call failed with a protocol error.
-    qserv_success
-        Successful Qserv query execution.
-    bigquery_success
-        Successful BigQuery query execution.
-    query_failure
-        Failed query.
     query_abort
         Aborted query.
+    query_api_failure
+        Failed API call to the backend, possibly retriable and thus not
+        indicating a failure of the whole query.
+    query_executing
+        Count of queries currently executing in the backend.
+    query_failure
+        Failed query.
+    query_success
+        Successful query execution.
+    temporary_table
+        Temporary table upload.
     """
 
     @override
     async def initialize(self, manager: EventManager) -> None:
-        self.qserv_executing = await manager.create_publisher(
-            "qserv_executing", QservExecutingEvent
-        )
-        self.bigquery_executing = await manager.create_publisher(
-            "bigquery_executing", BigQueryExecutingEvent
-        )
-        self.qserv_failure = await manager.create_publisher(
-            "qserv_failure", QservFailureEvent
-        )
-        self.bigquery_failure = await manager.create_publisher(
-            "bigquery_failure", BigQueryFailureEvent
-        )
-        self.qserv_success = await manager.create_publisher(
-            "qserv_success", QservSuccessEvent
-        )
-        self.bigquery_success = await manager.create_publisher(
-            "bigquery_success", BigQuerySuccessEvent
+        self.query_abort = await manager.create_publisher(
+            "query_abort", QueryAbortEvent
         )
         self.query_failure = await manager.create_publisher(
             "query_failure", QueryFailureEvent
         )
-        self.query_abort = await manager.create_publisher(
-            "query_abort", QueryAbortEvent
-        )
+        self.query_api_failure: EventPublisher[QueryApiFailureEvent]
+        self.query_success: EventPublisher[QuerySuccessEvent]
+        match config.backend:
+            case BackendType.QSERV:
+                self.query_api_failure = await manager.create_publisher(
+                    "qserv_failure", QservApiFailureEvent
+                )
+                self.query_executing = await manager.create_publisher(
+                    "qserv_executing", QueryExecutingEvent
+                )
+                self.query_success = await manager.create_publisher(
+                    "qserv_success", QservSuccessEvent
+                )
+            case BackendType.BIGQUERY:
+                self.query_api_failure = await manager.create_publisher(
+                    "bigquery_failure", BigQueryApiFailureEvent
+                )
+                self.query_executing = await manager.create_publisher(
+                    "bigquery_executing", QueryExecutingEvent
+                )
+                self.query_success = await manager.create_publisher(
+                    "bigquery_success", BigQuerySuccessEvent
+                )
         self.temporary_table = await manager.create_publisher(
             "temporary_table", TemporaryTableUploadEvent
         )

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -20,7 +20,7 @@ from structlog.stdlib import BoundLogger, get_logger
 
 from qservkafka.background import BackgroundTaskManager
 
-from .config import config
+from .config import BackendType, config
 from .constants import (
     REDIS_BACKOFF_MAX,
     REDIS_BACKOFF_START,
@@ -32,12 +32,8 @@ from .events import Events
 from .models.state import RunningQuery
 from .services.monitor import QueryMonitor
 from .services.query import QueryService
-from .services.results import (
-    BigQueryResultProcessor,
-    QservResultProcessor,
-    ResultProcessor,
-)
-from .storage.backend import BackendType, DatabaseBackend
+from .services.results import ResultProcessor
+from .storage.backend import DatabaseBackend
 from .storage.bigquery import BigQueryClient
 from .storage.gafaelfawr import GafaelfawrStorage
 from .storage.qserv import QservClient
@@ -439,19 +435,9 @@ class Factory:
         Returns
         -------
         ResultProcessor
-            New service to process a completed query. Returns the appropriate
-            subclass based on the configured backend.
+            New service to process a completed query.
         """
-        processor_class: type[ResultProcessor]
-        match config.backend:
-            case BackendType.QSERV:
-                processor_class = QservResultProcessor
-            case BackendType.BIGQUERY:
-                processor_class = BigQueryResultProcessor
-            case _:
-                raise ValueError(f"Unsupported backend type: {config.backend}")
-
-        return processor_class(
+        return ResultProcessor(
             backend=self.create_backend_client(),
             state_store=self.create_query_state_store(),
             votable_writer=VOTableWriter(

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -6,12 +6,11 @@ from collections import Counter
 from safir.arq import ArqQueue
 from structlog.stdlib import BoundLogger
 
-from ..config import config
-from ..events import BigQueryExecutingEvent, Events, QservExecutingEvent
+from ..events import Events, QueryExecutingEvent
 from ..exceptions import QueryError
 from ..models.query import AsyncQueryPhase, ProcessStatus
 from ..models.state import RunningQuery
-from ..storage.backend import BackendType, DatabaseBackend
+from ..storage.backend import DatabaseBackend
 from ..storage.rate import RateLimitStore
 from ..storage.state import QueryStateStore
 from .results import ResultProcessor
@@ -85,13 +84,8 @@ class QueryMonitor:
         # queries that are both still executing and that this bridge instance
         # is aware of, since the same backend may be shared by multiple
         # bridges and each should only count its own queries.
-        match config.backend:
-            case BackendType.BIGQUERY:
-                bq_event = BigQueryExecutingEvent(count=queries_executing)
-                await self._events.bigquery_executing.publish(bq_event)
-            case BackendType.QSERV:
-                qs_event = QservExecutingEvent(count=queries_executing)
-                await self._events.qserv_executing.publish(qs_event)
+        event = QueryExecutingEvent(count=queries_executing)
+        await self._events.query_executing.publish(event)
 
     async def check_query(
         self, query: RunningQuery, status: ProcessStatus | None

--- a/src/qservkafka/services/results.py
+++ b/src/qservkafka/services/results.py
@@ -1,10 +1,8 @@
 """Processing of completed queries."""
 
 import asyncio
-from abc import ABC, abstractmethod
 from dataclasses import asdict
-from datetime import UTC, datetime, timedelta
-from typing import override
+from datetime import UTC, datetime
 
 from faststream.kafka import KafkaBroker
 from safir.arq import ArqQueue
@@ -13,17 +11,13 @@ from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
 
-from ..config import config
+from ..config import BackendType, config
 from ..events import (
-    BigQueryFailureEvent,
     BigQuerySuccessEvent,
     Events,
-    QservFailureEvent,
-    QservProtocol,
     QservSuccessEvent,
     QueryAbortEvent,
     QueryFailureEvent,
-    QuerySuccessEvent,
 )
 from ..exceptions import (
     BackendApiError,
@@ -41,14 +35,10 @@ from ..storage.rate import RateLimitStore
 from ..storage.state import QueryStateStore
 from ..storage.votable import VOTableWriter
 
-__all__ = [
-    "BigQueryResultProcessor",
-    "QservResultProcessor",
-    "ResultProcessor",
-]
+__all__ = ["ResultProcessor"]
 
 
-class ResultProcessor(ABC):
+class ResultProcessor:
     """Process the results of a completed query.
 
     Parameters
@@ -95,6 +85,15 @@ class ResultProcessor(ABC):
         self._events = events
         self._slack_client = slack_client
         self._logger = logger
+
+        self._success_event_class: type[
+            BigQuerySuccessEvent | QservSuccessEvent
+        ]
+        match config.backend:
+            case BackendType.QSERV:
+                self._success_event_class = QservSuccessEvent
+            case BackendType.BIGQUERY:
+                self._success_event_class = BigQuerySuccessEvent
 
     async def delete_query_data(self, query: StartedQuery) -> None:
         """Delete stored information for the query.
@@ -247,41 +246,6 @@ class ResultProcessor(ABC):
             headers={"Content-Type": "application/json"},
         )
 
-    @abstractmethod
-    async def publish_success_event(
-        self,
-        *,
-        query: RunningQuery,
-        stats: UploadStats,
-        elapsed: timedelta,
-        backend_elapsed: timedelta,
-        backend_rate: float | None,
-    ) -> QuerySuccessEvent:
-        """Publish backend-specific success event.
-
-        Parameters
-        ----------
-        query
-            Query metadata.
-        stats
-            Upload statistics.
-        elapsed
-            Total elapsed time.
-        backend_elapsed
-            Time spent in backend.
-        backend_rate
-            Backend processing rate (bytes/sec).
-
-        Returns
-        -------
-        QuerySuccessEvent
-            The published event for logging.
-        """
-
-    @abstractmethod
-    async def _publish_backend_failure_event(self) -> None:
-        """Publish backend-specific failure event during retry."""
-
     async def _build_aborted_status(self, query: RunningQuery) -> JobStatus:
         """Construct the status for an aborted job.
 
@@ -341,16 +305,26 @@ class ResultProcessor(ABC):
         else:
             backend_rate = None
         elapsed = now - (query.queued or query.start)
-        event = await self.publish_success_event(
-            query=query,
-            stats=stats,
+        event = self._success_event_class(
+            job_id=query.job.job_id,
+            username=query.job.owner,
             elapsed=elapsed,
+            kafka_elapsed=query.start - query.queued if query.queued else None,
+            result_elapsed=stats.elapsed,
+            submit_elapsed=query.created - query.start,
+            rows=stats.rows,
+            encoded_size=stats.data_bytes,
+            result_size=stats.total_bytes,
+            rate=stats.data_bytes / elapsed.total_seconds(),
+            result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
+            upload_tables=len(query.job.upload_tables),
             backend_elapsed=backend_elapsed,
+            backend_size=query.status.collected_bytes,
             backend_rate=backend_rate,
         )
-        logger.info(
-            "Job complete and results uploaded", **event.to_logging_context()
-        )
+        await self._events.query_success.publish(event)
+        logger = logger.bind(**event.to_logging_context())
+        logger.info("Job complete and results uploaded")
 
         # Return the resulting status.
         return query.to_completed_job_status(stats)
@@ -519,7 +493,8 @@ class ResultProcessor(ABC):
             except (BackendApiTransientError, UploadWebError) as e:
                 delay = config.backend_retry_delay.total_seconds()
                 if isinstance(e, BackendApiTransientError):
-                    await self._publish_backend_failure_event()
+                    event = self._backend.result_api_failure_event()
+                    await self._events.query_api_failure.publish(event)
                     msg = f"Backend call failed, retrying after {delay}s"
                 else:
                     msg = f"Upload of results failed, retrying after {delay}s"
@@ -534,89 +509,6 @@ class ResultProcessor(ABC):
         try:
             return await self._upload_results(query)
         except BackendApiTransientError:
-            await self._publish_backend_failure_event()
+            event = self._backend.result_api_failure_event()
+            await self._events.query_api_failure.publish(event)
             raise
-
-
-class QservResultProcessor(ResultProcessor):
-    """Result processor for Qserv backend.
-
-    Publishes Qserv-specific metrics events.
-    """
-
-    @override
-    async def publish_success_event(
-        self,
-        *,
-        query: RunningQuery,
-        stats: UploadStats,
-        elapsed: timedelta,
-        backend_elapsed: timedelta,
-        backend_rate: float | None,
-    ) -> QservSuccessEvent:
-        event = QservSuccessEvent(
-            job_id=query.job.job_id,
-            username=query.job.owner,
-            elapsed=elapsed,
-            kafka_elapsed=query.start - query.queued if query.queued else None,
-            qserv_elapsed=backend_elapsed,
-            result_elapsed=stats.elapsed,
-            submit_elapsed=query.created - query.start,
-            rows=stats.rows,
-            qserv_size=query.status.collected_bytes,
-            encoded_size=stats.data_bytes,
-            result_size=stats.total_bytes,
-            rate=stats.data_bytes / elapsed.total_seconds(),
-            qserv_rate=backend_rate,
-            result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
-            upload_tables=len(query.job.upload_tables),
-        )
-        await self._events.qserv_success.publish(event)
-        return event
-
-    @override
-    async def _publish_backend_failure_event(self) -> None:
-        event = QservFailureEvent(protocol=QservProtocol.SQL)
-        await self._events.qserv_failure.publish(event)
-
-
-class BigQueryResultProcessor(ResultProcessor):
-    """Result processor for BigQuery backend.
-
-    Publishes BigQuery-specific metrics events.
-    """
-
-    @override
-    async def publish_success_event(
-        self,
-        *,
-        query: RunningQuery,
-        stats: UploadStats,
-        elapsed: timedelta,
-        backend_elapsed: timedelta,
-        backend_rate: float | None,
-    ) -> BigQuerySuccessEvent:
-        event = BigQuerySuccessEvent(
-            job_id=query.job.job_id,
-            username=query.job.owner,
-            elapsed=elapsed,
-            kafka_elapsed=query.start - query.queued if query.queued else None,
-            bigquery_elapsed=backend_elapsed,
-            result_elapsed=stats.elapsed,
-            submit_elapsed=query.created - query.start,
-            rows=stats.rows,
-            bigquery_size=query.status.collected_bytes,
-            bigquery_rate=backend_rate,
-            encoded_size=stats.data_bytes,
-            result_size=stats.total_bytes,
-            rate=stats.data_bytes / elapsed.total_seconds(),
-            result_rate=stats.data_bytes / stats.elapsed.total_seconds(),
-            upload_tables=len(query.job.upload_tables),
-        )
-        await self._events.bigquery_success.publish(event)
-        return event
-
-    @override
-    async def _publish_backend_failure_event(self) -> None:
-        event = BigQueryFailureEvent()
-        await self._events.bigquery_failure.publish(event)

--- a/src/qservkafka/storage/backend.py
+++ b/src/qservkafka/storage/backend.py
@@ -4,29 +4,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Sequence
-from enum import StrEnum
 from typing import Any
 
+from ..events import QueryApiFailureEvent
 from ..models.kafka import JobRun, JobTableUpload
 from ..models.qserv import TableUploadStats
 from ..models.query import ProcessStatus, QueryStatus
 
-__all__ = [
-    "BackendType",
-    "DatabaseBackend",
-]
-
-
-class BackendType(StrEnum):
-    """Supported database backend types.
-
-    These values use canonical capitalization (Qserv, BigQuery). Metrics
-    events use separate hardcoded names (qserv_success, bigquery_success)
-    so changes here don't affect metrics dashboards.
-    """
-
-    QSERV = "Qserv"
-    BIGQUERY = "BigQuery"
+__all__ = ["DatabaseBackend"]
 
 
 class DatabaseBackend(ABC):
@@ -163,6 +148,23 @@ class DatabaseBackend(ABC):
         Some backends may not support listing all running
         queries. In such cases, implementations should return an empty dict
         and rely on status polling of known queries instead.
+        """
+
+    @abstractmethod
+    def result_api_failure_event(self) -> QueryApiFailureEvent:
+        """Return an appropriate API failure event for result retrieval.
+
+        Different backends use different metrics events, possibly with
+        parameters, for a failure in retrieving results. This event cannot be
+        easily logged from inside the result iterator and therefore must be
+        logged by the results service, but it is backend-agnostic. It
+        therefore calls this method to retrieve the appropriate event to log.
+
+        Returns
+        -------
+        QueryApiFailureEvent
+            Appropriate event to log for a backend failure while retrieving
+            results.
         """
 
     @abstractmethod

--- a/src/qservkafka/storage/bigquery.py
+++ b/src/qservkafka/storage/bigquery.py
@@ -22,7 +22,7 @@ from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
 
 from ..config import config
-from ..events import BigQueryFailureEvent, Events
+from ..events import BigQueryApiFailureEvent, Events, QueryApiFailureEvent
 from ..exceptions import (
     BackendNotImplementedError,
     BigQueryApiNetworkError,
@@ -80,8 +80,8 @@ def _retry[**P, T, C: _BigQueryClientProtocol](
                 delay = config.backend_retry_delay.total_seconds()
                 msg = f"BigQuery API call failed, retrying after {delay}s"
                 client.logger.exception(msg)
-                event = BigQueryFailureEvent()
-                await client.events.bigquery_failure.publish(event)
+                event = BigQueryApiFailureEvent()
+                await client.events.query_api_failure.publish(event)
                 await asyncio.sleep(delay)
 
         # Fell through so failed max_tries - 1 times. Try one last time,
@@ -89,8 +89,8 @@ def _retry[**P, T, C: _BigQueryClientProtocol](
         try:
             return await __func(client, *args, **kwargs)
         except BigQueryApiNetworkError:
-            event = BigQueryFailureEvent()
-            await client.events.bigquery_failure.publish(event)
+            event = BigQueryApiFailureEvent()
+            await client.events.query_api_failure.publish(event)
             raise
 
     return retry_wrapper
@@ -352,6 +352,10 @@ class BigQueryClient(DatabaseBackend):
             return processes
 
         return await asyncio.to_thread(_list_running)
+
+    @override
+    def result_api_failure_event(self) -> QueryApiFailureEvent:
+        return BigQueryApiFailureEvent()
 
     @override
     async def submit_query(self, job: JobRun) -> str:

--- a/src/qservkafka/storage/qserv.py
+++ b/src/qservkafka/storage/qserv.py
@@ -24,7 +24,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from structlog.stdlib import BoundLogger
 
 from ..config import config
-from ..events import Events, QservFailureEvent, QservProtocol
+from ..events import (
+    Events,
+    QservApiFailureEvent,
+    QservProtocol,
+    QueryApiFailureEvent,
+)
 from ..exceptions import (
     QservApiFailedError,
     QservApiProtocolError,
@@ -155,8 +160,8 @@ def _retry[**P, T, C: _QservClientProtocol](
                     # We don't want to notify Sentry or Slack about exceptions
                     # here because we are going to retry.
                     client.logger.exception(msg)
-                    event = QservFailureEvent(protocol=qserv_protocol)
-                    await client.events.qserv_failure.publish(event)
+                    event = QservApiFailureEvent(protocol=qserv_protocol)
+                    await client.events.query_api_failure.publish(event)
                     await asyncio.sleep(delay)
 
             # Fell through so failed max_tries - 1 times. Try one last time,
@@ -164,8 +169,8 @@ def _retry[**P, T, C: _QservClientProtocol](
             try:
                 return await f(client, *args, **kwargs)
             except QservApiSqlError, SlackWebException:
-                event = QservFailureEvent(protocol=qserv_protocol)
-                await client.events.qserv_failure.publish(event)
+                event = QservApiFailureEvent(protocol=qserv_protocol)
+                await client.events.query_api_failure.publish(event)
                 raise
 
         return retry_wrapper
@@ -306,6 +311,10 @@ class QservClient(DatabaseBackend):
             raise QservApiSqlError.from_exception(e) from e
         self.logger.debug("Listed running queries", count=len(processes))
         return processes
+
+    @override
+    def result_api_failure_event(self) -> QueryApiFailureEvent:
+        return QservApiFailureEvent(protocol=QservProtocol.SQL)
 
     @override
     async def submit_query(self, job: JobRun) -> str:

--- a/tests/kafka/query_test.py
+++ b/tests/kafka/query_test.py
@@ -80,8 +80,8 @@ async def test_success(
     assert set(redis_client.scan_iter("query:*")) == set()
 
     # Check that the correct metrics event was sent.
-    assert isinstance(factory.events.qserv_success, MockEventPublisher)
-    events = factory.events.qserv_success.published
+    assert isinstance(factory.events.query_success, MockEventPublisher)
+    events = factory.events.query_success.published
     assert len(events) == 1
     data.assert_pydantic_matches(events[0], "events/success-kafka")
     assert events[0].qserv_size == qserv_status.collected_bytes
@@ -124,8 +124,8 @@ async def test_immediate(
 
     redis_client = redis.get_client()
     assert set(redis_client.scan_iter("query:*")) == set()
-    assert isinstance(factory.events.qserv_success, MockEventPublisher)
-    events = factory.events.qserv_success.published
+    assert isinstance(factory.events.query_success, MockEventPublisher)
+    events = factory.events.query_success.published
     assert len(events) == 1
     data.assert_pydantic_matches(events[0], "events/success")
 

--- a/tests/services/monitor_test.py
+++ b/tests/services/monitor_test.py
@@ -33,8 +33,8 @@ async def test_dispatch(
     # Check running query status and see if the count of running queries is
     # logged properly as a metric.
     await monitor.check_status()
-    assert isinstance(factory.events.qserv_executing, MockEventPublisher)
-    events = factory.events.qserv_executing.published
+    assert isinstance(factory.events.query_executing, MockEventPublisher)
+    events = factory.events.query_executing.published
     assert len(events) == 1
     data.assert_pydantic_matches(events[0], "events/executing")
 

--- a/tests/services/query_test.py
+++ b/tests/services/query_test.py
@@ -109,8 +109,8 @@ async def test_immediate(
     assert not mock_qserv.results_stored
 
     # Check that the correct metrics event was sent.
-    assert isinstance(factory.events.qserv_success, MockEventPublisher)
-    events = factory.events.qserv_success.published
+    assert isinstance(factory.events.query_success, MockEventPublisher)
+    events = factory.events.query_success.published
     assert len(events) == 1
     event = events[0]
     data.assert_pydantic_matches(event, "events/success")
@@ -150,8 +150,8 @@ async def test_immediate(
     # If Qserv was configured to intermittently fail, check that we logged
     # metrics events recording the failures.
     if mock_qserv.flaky:
-        assert isinstance(factory.events.qserv_failure, MockEventPublisher)
-        factory.events.qserv_failure.published.assert_published(
+        assert isinstance(factory.events.query_api_failure, MockEventPublisher)
+        factory.events.query_api_failure.published.assert_published(
             [{"protocol": "HTTP"}, {"protocol": "SQL"}]
         )
 
@@ -209,8 +209,8 @@ async def test_no_delete(
     assert mock_qserv.results_stored
 
     # Check that the correct metrics events were sent.
-    assert isinstance(factory.events.qserv_success, MockEventPublisher)
-    events = factory.events.qserv_success.published
+    assert isinstance(factory.events.query_success, MockEventPublisher)
+    events = factory.events.query_success.published
     assert len(events) == 1
     data.assert_pydantic_matches(events[0], "events/success-no-delete")
 
@@ -404,8 +404,8 @@ async def test_upload(
     assert mock_qserv.get_uploaded_database() is None
 
     # Check that the correct metrics events were sent.
-    assert isinstance(factory.events.qserv_success, MockEventPublisher)
-    events = factory.events.qserv_success.published
+    assert isinstance(factory.events.query_success, MockEventPublisher)
+    events = factory.events.query_success.published
     assert len(events) == 1
     data.assert_pydantic_matches(events[0], "events/success-upload")
     assert isinstance(factory.events.temporary_table, MockEventPublisher)

--- a/tests/storage/query_test.py
+++ b/tests/storage/query_test.py
@@ -9,6 +9,7 @@ from typing import Any, override
 import pytest
 from pydantic import HttpUrl, TypeAdapter
 
+from qservkafka.events import QueryApiFailureEvent
 from qservkafka.models.kafka import (
     JobResultConfig,
     JobResultEnvelope,
@@ -129,6 +130,10 @@ class MockDatabaseBackend(DatabaseBackend):
     async def delete_database(self, database: str) -> None:
         """Mock database deletion."""
         self.deleted_databases.append(database)
+
+    @override
+    def result_api_failure_event(self) -> QueryApiFailureEvent:
+        return QueryApiFailureEvent()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Use validation aliases and conditionals to expose consistent event publisher names and APIs to hide the fact that we made the poor decision to use different field names for different backends. This significantly simplifies the code and removes the need to subclass the results service.