### PR TITLE
DM-55758: Refactor factory and process context

### DIFF
--- a/src/qservkafka/dependencies/context.py
+++ b/src/qservkafka/dependencies/context.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from faststream.kafka.fastapi import KafkaMessage
 from structlog.stdlib import BoundLogger, get_logger
 
-from ..factory import Factory, ProcessContext
+from ..factory import Factory, ProcessContext, build_process_context
 
 __all__ = [
     "ConsumerContext",
@@ -20,14 +20,14 @@ __all__ = [
 class ConsumerContext:
     """Context for a Kafka consumer."""
 
-    logger: BoundLogger
-    """Logger for the consumer."""
-
     factory: Factory
     """The component factory."""
 
     message_timestamp: datetime
     """Timestamp of the message, extracted from the Kafka header."""
+
+    logger: BoundLogger
+    """Logger for the consumer."""
 
 
 class ContextDependency:
@@ -40,13 +40,10 @@ class ContextDependency:
     """
 
     def __init__(self) -> None:
-        self._process_context: ProcessContext | None = None
+        self._context: ProcessContext | None = None
 
     async def __call__(self, message: KafkaMessage) -> ConsumerContext:
         """Create a per-request context."""
-        if not self._process_context:
-            raise RuntimeError("Context dependency not initialized")
-
         # The underlying Kafka messages can either be a single message or a
         # tuple of messages. Since we only are using them to extract some
         # metadata for logging purposes, use the first message if there are
@@ -68,38 +65,42 @@ class ContextDependency:
         timestamp = datetime.fromtimestamp(record.timestamp / 1000, tz=UTC)
         return ConsumerContext(
             logger=logger,
-            factory=Factory(self._process_context, logger),
+            factory=self.create_factory(logger),
             message_timestamp=timestamp,
         )
 
     async def aclose(self) -> None:
         """Clean up the per-process singletons."""
-        if self._process_context:
-            await self._process_context.aclose()
-        self._process_context = None
+        if self._context:
+            await self._context.aclose()
+        self._context = None
 
-    def create_factory(self) -> Factory:
+    def create_factory(self, logger: BoundLogger | None = None) -> Factory:
         """Create a new factory.
 
         This is used for background processing, so it is separate from the
         work inside ``__call__``, which assumes that there is a Kafka message
         to which the bridge is reacting.
 
+        Parameters
+        ----------
+        logger
+            Logger to use. If not given, the default logger will be used.
+
         Returns
         -------
         Factory
             Newly-constructed factory.
         """
-        if not self._process_context:
+        if not self._context:
             raise RuntimeError("Context dependency not initialized")
-        logger = get_logger("qservkafka")
-        return Factory(self._process_context, logger)
+        if not logger:
+            logger = get_logger("qservkafka")
+        return self._context.build_factory(logger)
 
     async def initialize(self) -> None:
         """Initialize the process-wide shared context."""
-        if self._process_context:
-            await self.aclose()
-        self._process_context = await ProcessContext.create()
+        self._context = await build_process_context()
 
 
 context_dependency = ContextDependency()

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -1,8 +1,9 @@
 """Create Qserv Kafka bridge components."""
 
 import ssl
+from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Self
+from typing import Any, Self, override
 
 from faststream.kafka import KafkaBroker
 from httpx import AsyncClient, Limits
@@ -12,6 +13,7 @@ from redis.backoff import ExponentialBackoff
 from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqMode, ArqQueue, MockArqQueue, RedisArqQueue
 from safir.database import create_database_engine
+from safir.dependencies.http_client import http_client_dependency
 from safir.metrics import EventManager
 from safir.redis import PydanticRedisStorage
 from safir.slack.webhook import SlackWebhookClient
@@ -41,11 +43,16 @@ from .storage.rate import RateLimitStore
 from .storage.state import QueryStateStore
 from .storage.votable import VOTableWriter
 
-__all__ = ["Factory", "ProcessContext"]
+__all__ = [
+    "Factory",
+    "ProcessContext",
+    "QservProcessContext",
+    "build_process_context",
+]
 
 
 @dataclass(kw_only=True, slots=True)
-class ProcessContext:
+class ProcessContext(metaclass=ABCMeta):
     """Per-process application context.
 
     This object caches all of the per-process singletons that can be reused
@@ -54,38 +61,225 @@ class ProcessContext:
     """
 
     http_client: AsyncClient
-    """Shared HTTP client."""
-
-    discovery_client: DiscoveryClient
-    """Shared service discovery client."""
-
-    engine: AsyncEngine | None
-    """Database engine (only for Qserv backend)."""
-
-    sessionmaker: async_sessionmaker | None
-    """Factory for database sessions (only for Qserv backend)."""
-
-    kafka_broker: KafkaBroker
-    """Kafka broker to use for publishing messages from background jobs."""
-
-    arq_queue: ArqQueue
-    """Queue to which to dispatch work to arq workers."""
-
-    event_manager: EventManager
-    """Manager for publishing metrics events."""
-
-    slack_client: SlackWebhookClient | None
-    """Client for sending Slack error notifications."""
-
-    gafaelfawr: GafaelfawrStorage
-    """Shared caching Gafaelfawr storage."""
-
-    events: Events
-    """Event publishers for metrics events."""
+    """HTTP client used for talking to the backend."""
 
     redis: Redis
     """Connection pool for state-tracking Redis."""
 
+    arq_queue: ArqQueue
+    """Queue to which to dispatch work to arq workers."""
+
+    kafka_broker: KafkaBroker
+    """Kafka broker to use for publishing messages from background jobs."""
+
+    slack_client: SlackWebhookClient | None
+    """Client for sending Slack error notifications."""
+
+    discovery_client: DiscoveryClient
+    """Shared service discovery client."""
+
+    gafaelfawr: GafaelfawrStorage
+    """Shared caching Gafaelfawr storage."""
+
+    event_manager: EventManager
+    """Manager for publishing metrics events."""
+
+    events: Events
+    """Event publishers for metrics events."""
+
+    @classmethod
+    async def build_shared_context(
+        cls, kafka_broker: KafkaBroker | None = None
+    ) -> dict[str, Any]:
+        """Create shared `ProcessContext` attributes.
+
+        This method should only be called by subclasses as part of their
+        `create` method. It creates all the shared data for a process context
+        and returns it as a dictionary suiltable for providing keyword
+        parameters to a class constructor.
+
+        Parameters
+        ----------
+        kafka_broker
+            If not `None`, use this Kafka broker instead of making a new one.
+
+        Returns
+        -------
+        dict
+            Shared context for the process.
+        """
+        logger = get_logger("qservkafka")
+
+        # Create a Redis client pool with exponential backoff and the state
+        # store that stores job state in Redis.
+        redis_client = cls._create_redis_client()
+
+        # Create the arq queues with their underlying Redis clients.
+        arq_queue = await cls._create_arq_queue()
+
+        # Create a Kafka broker used for background tasks. This needs to be a
+        # separate broker from the one used by handlers, since the one used by
+        # handlers will be shut down when SIGTERM is retrieved, thus
+        # preventing the Qserv Kafka bridge from completing any result
+        # processing that is still running.
+        if not kafka_broker:
+            kafka_broker = KafkaBroker(
+                client_id="qserv-kafka", **config.kafka.to_faststream_params()
+            )
+        await kafka_broker.connect()
+
+        # Create the HTTP, Slack, service discovery, and Gafaelfawr clients,
+        # all using the same HTTP connection pool.
+        slack_client = cls._create_slack_client(logger)
+        http_client = await http_client_dependency()
+        discovery_client = DiscoveryClient(http_client, logger=logger)
+        gafaelfawr = GafaelfawrStorage(
+            http_client=http_client,
+            discovery_client=discovery_client,
+            slack_client=slack_client,
+            logger=logger,
+        )
+
+        # Create the events manager and publishers.
+        event_manager = config.metrics.make_manager(kafka_broker=kafka_broker)
+        await event_manager.initialize()
+        events = Events()
+        await events.initialize(event_manager)
+
+        # Create and return the process context.
+        return {
+            "http_client": http_client,
+            "redis": redis_client,
+            "arq_queue": arq_queue,
+            "discovery_client": discovery_client,
+            "kafka_broker": kafka_broker,
+            "gafaelfawr": gafaelfawr,
+            "event_manager": event_manager,
+            "events": events,
+            "slack_client": slack_client,
+        }
+
+    @staticmethod
+    async def _create_arq_queue() -> ArqQueue:
+        """Create the queue used to dispatch work to arq workers."""
+        if config.arq_mode == ArqMode.production:
+            settings = config.arq_redis_settings
+            return await RedisArqQueue.initialize(
+                settings, default_queue_name=config.arq_queue
+            )
+        else:
+            return MockArqQueue()
+
+    @staticmethod
+    def _create_redis_client() -> Redis:
+        """Create the Redis client pool with exponential backoff."""
+        redis_password = config.redis_password.get_secret_value()
+        backoff = ExponentialBackoff(
+            base=REDIS_BACKOFF_START, cap=REDIS_BACKOFF_MAX
+        )
+        redis_pool = BlockingConnectionPool.from_url(
+            str(config.redis_url),
+            password=redis_password,
+            max_connections=config.redis_max_connections,
+            retry=Retry(backoff, REDIS_RETRIES),
+            retry_on_timeout=True,
+            socket_keepalive=True,
+            socket_timeout=REDIS_TIMEOUT,
+            timeout=REDIS_POOL_TIMEOUT,
+        )
+        return Redis.from_pool(redis_pool)
+
+    @staticmethod
+    def _create_slack_client(logger: BoundLogger) -> SlackWebhookClient | None:
+        """Create the Slack client for error notifications."""
+        if not config.slack.enabled:
+            return None
+        if config.slack.webhook is None:
+            msg = "Slack: if enabled is true, then webhook must be set"
+            raise RuntimeError(msg)
+        return SlackWebhookClient(
+            hook_url=config.slack.webhook,
+            application="qserv-kafka",
+            logger=logger,
+        )
+
+    @classmethod
+    async def create(cls, kafka_broker: KafkaBroker | None = None) -> Self:
+        """Create a new process context from a database engine.
+
+        Parameters
+        ----------
+        kafka_broker
+            If not `None`, use this Kafka broker instead of making a new one.
+
+        Returns
+        -------
+        ProcessContext
+            Shared context for a Qserv Kafka bridge process.
+        """
+        shared = await cls.build_shared_context(kafka_broker)
+        return cls(**shared)
+
+    async def aclose(self) -> None:
+        """Clean up a process context.
+
+        Called during shutdown, or before recreating the process context using
+        a different configuration.
+        """
+        await self.redis.aclose()
+        await self.arq_queue.aclose()
+        await self.kafka_broker.stop()
+        await self.event_manager.aclose()
+
+    @abstractmethod
+    def build_factory(self, logger: BoundLogger) -> Factory:
+        """Construct an appropriate factory for this process context.
+
+        Parameters
+        ----------
+        logger
+            Logger to use.
+
+        Returns
+        -------
+        Factory
+            An appropriate factory for the configured backend.
+        """
+
+
+@dataclass(kw_only=True, slots=True)
+class BigQueryProcessContext(ProcessContext):
+    """Per-process application context for BigQuery.
+
+    This object caches all of the per-process singletons that can be reused
+    for every incoming message and only need to be recreated if the
+    application configuration changes.
+    """
+
+    @override
+    def build_factory(self, logger: BoundLogger) -> Factory:
+        return BigQueryFactory(self, logger)
+
+
+@dataclass(kw_only=True, slots=True)
+class QservProcessContext(ProcessContext):
+    """Per-process application context for Qserv.
+
+    This object caches all of the per-process singletons that can be reused
+    for every incoming message and only need to be recreated if the
+    application configuration changes.
+    """
+
+    engine: AsyncEngine
+    """Database engine."""
+
+    sessionmaker: async_sessionmaker
+    """Factory for database sessions."""
+
+    qserv_http_client: AsyncClient
+    """HTTP client for talking to Qserv."""
+
+    @override
     @classmethod
     async def create(
         cls,
@@ -109,195 +303,97 @@ class ProcessContext:
         ProcessContext
             Shared context for a Qserv Kafka bridge process.
         """
-        logger = get_logger("qservkafka")
+        if config.qserv_database_url is None:
+            msg = "qserv_database_url is required for Qserv backend"
+            raise ValueError(msg)
+        shared = await cls.build_shared_context(kafka_broker)
 
-        # Create HTTP client and SSL context with backend-specific config.
-        http_client = cls._create_http_client()
-        ssl_context = cls._create_ssl_context()
+        # Qserv uses a self-signed certificate with no known certificate
+        # chain. We do not use TLS to validate the identity of the server.
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
 
-        # Create a Redis client pool with exponential backoff and the state
-        # store that stores job state in Redis.
-        redis_client = cls._create_redis_client()
-
-        # Create the database engine (only for Qserv backend).
-        engine, sessionmaker = cls._create_database_engine(
-            ssl_context, qserv_database_pool_size
+        # Qserv uses a self-signed certificate and has configuration settings
+        # for maximum simultaneous connections.
+        qserv_http_client = AsyncClient(
+            timeout=config.backend_api_timeout.total_seconds(),
+            limits=Limits(max_connections=config.qserv_rest_max_connections),
+            verify=False,  # noqa: S501
         )
 
-        # Create a Kafka broker used for background tasks. This needs to be a
-        # separate broker from the one used by handlers, since the one used by
-        # handlers will be shut down when SIGTERM is retrieved, thus
-        # preventing the Qserv Kafka bridge from completing any result
-        # processing that is still running.
-        if not kafka_broker:
-            kafka_broker = KafkaBroker(
-                client_id="qserv-kafka", **config.kafka.to_faststream_params()
-            )
-        await kafka_broker.connect()
-
-        event_manager = config.metrics.make_manager(kafka_broker=kafka_broker)
-        await event_manager.initialize()
-        events = Events()
-        await events.initialize(event_manager)
-
-        slack_client = cls._create_slack_client(logger)
-        discovery_client = DiscoveryClient(http_client)
-        gafaelfawr = GafaelfawrStorage(
-            http_client=http_client,
-            discovery_client=discovery_client,
-            slack_client=slack_client,
-            logger=logger,
+        # Create the database engine and sessionmaker.
+        pool_size = qserv_database_pool_size or config.qserv_database_pool_size
+        connect_args = {
+            "ssl": ssl_context,
+            "connect_timeout": config.qserv_database_connect_timeout,
+            "read_timeout": config.qserv_database_read_timeout,
+        }
+        engine = create_database_engine(
+            str(config.qserv_database_url),
+            config.qserv_database_password,
+            connect_args=connect_args,
+            max_overflow=config.qserv_database_overflow,
+            pool_size=pool_size,
         )
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
 
-        arq_queue = await cls._create_arq_queue()
-
+        # Construct the Qserv-specific process context.
         return cls(
-            http_client=http_client,
-            discovery_client=discovery_client,
             engine=engine,
             sessionmaker=sessionmaker,
-            kafka_broker=kafka_broker,
-            event_manager=event_manager,
-            slack_client=slack_client,
-            gafaelfawr=gafaelfawr,
-            events=events,
-            redis=redis_client,
-            arq_queue=arq_queue,
+            qserv_http_client=qserv_http_client,
+            **shared,
         )
 
-    @classmethod
-    def _create_http_client(cls) -> AsyncClient:
-        """Create the shared HTTP client with backend-specific config."""
-        match config.backend:
-            case BackendType.QSERV:
-                # Qserv uses a self-signed certificate.
-                limits = Limits(
-                    max_connections=config.qserv_rest_max_connections
-                )
-                return AsyncClient(
-                    timeout=config.backend_api_timeout.total_seconds(),
-                    limits=limits,
-                    verify=False,  # noqa: S501
-                )
-            case BackendType.BIGQUERY:
-                # BigQuery uses standard HTTPS.
-                return AsyncClient()
-
-    @classmethod
-    def _create_ssl_context(cls) -> ssl.SSLContext | None:
-        """Create SSL context for database connections (Qserv only)."""
-        match config.backend:
-            case BackendType.QSERV:
-                # Qserv uses a self-signed certificate with no known
-                # certificate chain. We do not use TLS to validate the
-                # identity of the server.
-                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-                ssl_context.check_hostname = False
-                ssl_context.verify_mode = ssl.CERT_NONE
-                return ssl_context
-            case BackendType.BIGQUERY:
-                return None
-
-    @classmethod
-    def _create_redis_client(cls) -> Redis:
-        """Create the Redis client pool with exponential backoff."""
-        redis_password = config.redis_password.get_secret_value()
-        backoff = ExponentialBackoff(
-            base=REDIS_BACKOFF_START, cap=REDIS_BACKOFF_MAX
-        )
-        redis_pool = BlockingConnectionPool.from_url(
-            str(config.redis_url),
-            password=redis_password,
-            max_connections=config.redis_max_connections,
-            retry=Retry(backoff, REDIS_RETRIES),
-            retry_on_timeout=True,
-            socket_keepalive=True,
-            socket_timeout=REDIS_TIMEOUT,
-            timeout=REDIS_POOL_TIMEOUT,
-        )
-        return Redis.from_pool(redis_pool)
-
-    @classmethod
-    def _create_database_engine(
-        cls,
-        ssl_context: ssl.SSLContext | None,
-        pool_size_override: int | None,
-    ) -> tuple[AsyncEngine | None, async_sessionmaker | None]:
-        """Create the database engine and sessionmaker (Qserv only)."""
-        match config.backend:
-            case BackendType.QSERV:
-                if config.qserv_database_url is None:
-                    msg = "qserv_database_url is required for Qserv backend"
-                    raise ValueError(msg)
-                pool_size = (
-                    pool_size_override or config.qserv_database_pool_size
-                )
-                connect_args = {
-                    "ssl": ssl_context,
-                    "connect_timeout": config.qserv_database_connect_timeout,
-                    "read_timeout": config.qserv_database_read_timeout,
-                }
-                engine = create_database_engine(
-                    str(config.qserv_database_url),
-                    config.qserv_database_password,
-                    connect_args=connect_args,
-                    max_overflow=config.qserv_database_overflow,
-                    pool_size=pool_size,
-                )
-                sessionmaker = async_sessionmaker(
-                    engine, expire_on_commit=False
-                )
-                return engine, sessionmaker
-            case BackendType.BIGQUERY:
-                return None, None
-
-    @classmethod
-    async def _create_arq_queue(cls) -> ArqQueue:
-        """Create the queue used to dispatch work to arq workers."""
-        if config.arq_mode == ArqMode.production:
-            settings = config.arq_redis_settings
-            return await RedisArqQueue.initialize(
-                settings, default_queue_name=config.arq_queue
-            )
-        else:
-            return MockArqQueue()
-
-    @classmethod
-    def _create_slack_client(
-        cls, logger: BoundLogger
-    ) -> SlackWebhookClient | None:
-        """Create the Slack client for error notifications."""
-        if not config.slack.enabled:
-            return None
-        if config.slack.webhook is None:
-            msg = "Slack: if enabled is true, then webhook must be set"
-            raise RuntimeError(msg)
-        return SlackWebhookClient(
-            hook_url=config.slack.webhook,
-            application="qserv-kafka",
-            logger=logger,
-        )
-
+    @override
     async def aclose(self) -> None:
-        """Clean up a process context.
+        await super().aclose()
+        await self.engine.dispose()
+        await self.qserv_http_client.aclose()
 
-        Called during shutdown, or before recreating the process context using
-        a different configuration.
-        """
-        await self.event_manager.aclose()
-        await self.kafka_broker.stop()
-        await self.arq_queue.aclose()
-        await self.redis.aclose()
-        if self.engine is not None:
-            await self.engine.dispose()
-        await self.http_client.aclose()
+    @override
+    def build_factory(self, logger: BoundLogger) -> Factory:
+        return QservFactory(self, logger)
 
 
-class Factory:
-    """Build Qserv Kafka bridge components.
+async def build_process_context(
+    kafka_broker: KafkaBroker | None = None,
+    *,
+    worker_max_jobs: int | None = None,
+) -> ProcessContext:
+    """Construct a new process context of the appropriate type.
+
+    Handles determining the backend type from the configuration and creating
+    an appropriate process context for either a backend worker or the frontend
+    service.
+
+    Parameters
+    ----------
+    kafka_broker
+        If not `None`, use this Kafka broker instead of making a new one.
+    worker_max_jobs
+        Maximum number of worker jobs if creating a process context for an
+        arq worker, or `None` if creating the frontend context.
+    """
+    match config.backend:
+        case BackendType.BIGQUERY:
+            return await ProcessContext.create(kafka_broker)
+        case BackendType.QSERV:
+            if worker_max_jobs is not None:
+                return await QservProcessContext.create(
+                    kafka_broker, qserv_database_pool_size=worker_max_jobs
+                )
+            else:
+                return await QservProcessContext.create(kafka_broker)
+
+
+class Factory(metaclass=ABCMeta):
+    """Build bridge components.
 
     Uses the contents of a `ProcessContext` to construct the components of the
-    application on demand.
+    application on demand. There are specialized versions of this class for
+    each backend.
 
     Parameters
     ----------
@@ -307,11 +403,7 @@ class Factory:
         Logger to use for errors.
     """
 
-    def __init__(
-        self,
-        context: ProcessContext,
-        logger: BoundLogger,
-    ) -> None:
+    def __init__(self, context: ProcessContext, logger: BoundLogger) -> None:
         self._context = context
         self._logger = logger
 
@@ -324,6 +416,16 @@ class Factory:
     def gafaelfawr(self) -> GafaelfawrStorage:
         """Global shared caching Gafaelfawr client."""
         return self._context.gafaelfawr
+
+    @abstractmethod
+    def create_backend_client(self) -> DatabaseBackend:
+        """Create a client for the configured database backend.
+
+        Returns
+        -------
+        DatabaseBackend
+            Client for the database backend.
+        """
 
     async def create_background_task_manager(self) -> BackgroundTaskManager:
         """Create the background task manager to monitor Qserv jobs.
@@ -352,42 +454,6 @@ class Factory:
             key_prefix="query:",
         )
         return QueryStateStore(redis_storage, self._logger)
-
-    def create_backend_client(self) -> DatabaseBackend:
-        """Create a client for the configured database backend.
-
-        Returns
-        -------
-        DatabaseBackend
-            Client for the database backend (Qserv or BigQuery).
-
-        Raises
-        ------
-        ValueError
-            If the backend type is not supported or required configuration
-            is missing.
-        """
-        match config.backend:
-            case BackendType.QSERV:
-                if self._context.sessionmaker is None:
-                    msg = "sessionmaker is required for Qserv backend"
-                    raise ValueError(msg)
-                return QservClient(
-                    sessionmaker=self._context.sessionmaker,
-                    http_client=self._context.http_client,
-                    events=self._context.events,
-                    slack_client=self._context.slack_client,
-                    logger=self._logger,
-                )
-            case BackendType.BIGQUERY:
-                return BigQueryClient(
-                    project=config.bigquery_project,
-                    location=config.bigquery_location,
-                    http_client=self._context.http_client,
-                    events=self._context.events,
-                    slack_client=self._context.slack_client,
-                    logger=self._logger,
-                )
 
     async def create_query_monitor(self) -> QueryMonitor:
         """Create the singleton monitor for query status.
@@ -462,3 +528,60 @@ class Factory:
             Storage for rate limit information.
         """
         return RateLimitStore(self._context.redis)
+
+
+class BigQueryFactory(Factory):
+    """Build BigQuery Kafka bridge components.
+
+    Uses the contents of a `ProcessContext` to construct the components of the
+    application on demand.
+
+    Parameters
+    ----------
+    context
+        Shared process context.
+    logger
+        Logger to use for errors.
+    """
+
+    @override
+    def create_backend_client(self) -> DatabaseBackend:
+        return BigQueryClient(
+            project=config.bigquery_project,
+            location=config.bigquery_location,
+            http_client=self._context.http_client,
+            events=self._context.events,
+            slack_client=self._context.slack_client,
+            logger=self._logger,
+        )
+
+
+class QservFactory(Factory):
+    """Build Qserv Kafka bridge components.
+
+    Uses the contents of a `QservProcessContext` to construct the components
+    of the application on demand.
+
+    Parameters
+    ----------
+    context
+        Shared process context.
+    logger
+        Logger to use for errors.
+    """
+
+    def __init__(
+        self, context: QservProcessContext, logger: BoundLogger
+    ) -> None:
+        self._context: QservProcessContext = context
+        self._logger = logger
+
+    @override
+    def create_backend_client(self) -> DatabaseBackend:
+        return QservClient(
+            sessionmaker=self._context.sessionmaker,
+            http_client=self._context.qserv_http_client,
+            events=self._context.events,
+            slack_client=self._context.slack_client,
+            logger=self._logger,
+        )

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -15,7 +15,7 @@ from structlog.stdlib import get_logger
 from .. import __version__
 from ..config import config
 from ..constants import ARQ_TIMEOUT_GRACE
-from ..factory import Factory, ProcessContext
+from ..factory import ProcessContext, build_process_context
 from .functions.results import handle_finished_query
 from .functions.upload import handle_upload_job
 
@@ -41,13 +41,10 @@ async def startup(ctx: dict[Any, Any]) -> None:
 
     # Allow the test suite to override the process context to, for example,
     # provide mock metrics event publishers that are accessible to the test.
-    if "context" in ctx:
-        context = ctx["context"]
-    else:
-        context = await ProcessContext.create(
-            qserv_database_pool_size=config.max_worker_jobs
-        )
-    factory = Factory(context, logger)
+    context = ctx.get("context")
+    if not context:
+        context = await build_process_context(worker_max_jobs=ctx["max_jobs"])
+    factory = context.build_factory(logger)
 
     # Metrics initialization must be done exactly once. If not done at all,
     # the on_job_start function fails; if done more than once, Safir's metrics
@@ -79,16 +76,17 @@ class WorkerSettings:
     """Configuration for the arq worker that processes completed queries."""
 
     functions: ClassVar[list[Callable]] = [handle_finished_query]
+    queue_name = config.arq_queue
+    redis_settings = config.arq_redis_settings
+    on_startup = startup
+    on_shutdown = shutdown
+    on_job_start = make_on_job_start(config.arq_queue)
     job_completion_wait = int(
         (config.result_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
     )
-    job_timeout = config.result_timeout + ARQ_TIMEOUT_GRACE
     max_jobs = config.max_worker_jobs
-    on_job_start = make_on_job_start(config.arq_queue)
-    on_startup = startup
-    on_shutdown = shutdown
-    queue_name = config.arq_queue
-    redis_settings = config.arq_redis_settings
+    job_timeout = config.result_timeout + ARQ_TIMEOUT_GRACE
+    ctx: ClassVar[dict[str, int]] = {"max_jobs": config.max_worker_jobs}
 
 
 class UploadWorkerSettings:
@@ -104,12 +102,13 @@ class UploadWorkerSettings:
             timeout=config.upload_worker_timeout + ARQ_TIMEOUT_GRACE,
         ),
     ]
+    queue_name = config.upload_queue
+    redis_settings = config.arq_redis_settings
+    on_startup = startup
+    on_shutdown = shutdown
+    on_job_start = make_on_job_start(config.upload_queue)
     job_completion_wait = int(
         (config.upload_worker_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
     )
     max_jobs = config.upload_worker_max_jobs
-    on_job_start = make_on_job_start(config.upload_queue)
-    on_startup = startup
-    on_shutdown = shutdown
-    queue_name = config.upload_queue
-    redis_settings = config.arq_redis_settings
+    ctx: ClassVar[dict[str, int]] = {"max_jobs": config.upload_worker_max_jobs}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from testcontainers.mysql import MySqlContainer
 from testcontainers.redis import RedisContainer
 
 from qservkafka.config import config
-from qservkafka.factory import Factory, ProcessContext
+from qservkafka.factory import Factory, build_process_context
 from qservkafka.main import create_app
 
 from .support.constants import REDIS_IMAGE
@@ -119,9 +119,9 @@ async def factory(
     monkeypatch.setattr(config, "redis_url", redis_url)
     kafka_broker = KafkaBroker(**config.kafka.to_faststream_params())
     async with TestKafkaBroker(kafka_broker) as mock_broker:
-        context = await ProcessContext.create(mock_broker)
+        context = await build_process_context(mock_broker)
         async with aclosing(context):
-            yield Factory(context, logger)
+            yield context.build_factory(logger)
     await kafka_broker.stop()
 
 

--- a/tests/support/arq.py
+++ b/tests/support/arq.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import inspect
+from copy import copy
 from datetime import timedelta
 from typing import Any
 
@@ -37,7 +38,7 @@ def create_arq_worker(
     Worker
         arq worker.
     """
-    ctx = {}
+    ctx = copy(settings.ctx)
     if context:
         ctx["context"] = context
     settings.redis_settings = config.arq_redis_settings
@@ -45,7 +46,11 @@ def create_arq_worker(
     return Worker(
         burst=True,
         ctx=ctx,
-        **{k: v for k, v in vars(settings).items() if k in worker_args},
+        **{
+            k: v
+            for k, v in vars(settings).items()
+            if k in worker_args and k != "ctx"
+        },
     )
 
 


### PR DESCRIPTION
Previously, the bridge regardless of backend was sharing one factory and process context implementation. This required optional fields, embedded checks, match statements, and other machinery to provide different behavior based on the backend and did not use the type system correctly.

Rework this to instead specialize the process context and the factory based on the backend type and add an additional function and method to build a correctly-typed process context and factory. This moves all of those checks to the type system.