### PR TITLE
DM-55758: Rename the settings for the arq queues

### DIFF
--- a/changelog.d/20260813_174639_rra_DM_55758.md
+++ b/changelog.d/20260813_174639_rra_DM_55758.md
@@ -1,0 +1,4 @@
+### Backwards-incompatible changes
+
+- Rename the worker pools to fast and slow and change the configuration settings accordingly. The maximum number of jobs is now configured with `arqFastMaxJobs` and `arqSlowMaxJobs`.
+- Remove the separate `uploadWorkerTimeout` setting. This is now configured based on the Qserv upload timeout.

--- a/src/qservkafka/config.py
+++ b/src/qservkafka/config.py
@@ -23,6 +23,8 @@ from safir.logging import LogLevel, Profile
 from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 from safir.pydantic import EnvRedisDsn, HumanTimedelta
 
+from .constants import ARQ_TIMEOUT_GRACE
+
 __all__ = [
     "BackendType",
     "Config",
@@ -97,13 +99,16 @@ class Config(BaseSettings):
         env_prefix="QSERV_KAFKA_", case_sensitive=False
     )
 
-    arq_mode: ArqMode = Field(
-        ArqMode.production,
-        title="arq queue mode",
-        description="Used by the test suite to switch to a mock queue",
+    arq_fast_max_jobs: int = Field(
+        50,
+        title="Concurrent fast worker jobs per pod",
+        description=(
+            "Fast jobs are I/O-bound, so default to a higher default than"
+            " the slow queue for CPU-intensive workers"
+        ),
     )
 
-    arq_queue_fast: str = Field(
+    arq_fast_queue: str = Field(
         "arq:upload",
         title="arq queue for fast actions",
         description=(
@@ -113,7 +118,22 @@ class Config(BaseSettings):
         ),
     )
 
-    arq_queue_slow: str = Field(
+    arq_mode: ArqMode = Field(
+        ArqMode.production,
+        title="arq queue mode",
+        description="Used by the test suite to switch to a mock queue",
+    )
+
+    arq_slow_max_jobs: int = Field(
+        2,
+        title="Concurrent result worker jobs per pod",
+        description=(
+            "Result workers can only use one CPU and are CPU-bound, so setting"
+            " this value higher than 2 will normally not be helpful"
+        ),
+    )
+
+    arq_slow_queue: str = Field(
         default_queue_name,
         title="arq queue for slow actions",
         description=(
@@ -233,15 +253,6 @@ class Config(BaseSettings):
 
     log_profile: Profile = Field(
         Profile.production, title="Application logging profile"
-    )
-
-    max_worker_jobs: int = Field(
-        2,
-        title="Concurrent result worker jobs per pod",
-        description=(
-            "Result workers can only use one CPU and are CPU-bound, so setting"
-            " this value higher than 2 will normally not be helpful"
-        ),
     )
 
     metrics: MetricsConfiguration = Field(
@@ -410,24 +421,6 @@ class Config(BaseSettings):
         description="Used to determine which TAP quota to apply",
     )
 
-    upload_worker_max_jobs: int = Field(
-        10,
-        title="Concurrent upload worker jobs per pod",
-        description=(
-            "Table uploads are I/O-bound so we default to a higher "
-            " default than the result-processing worker pool"
-        ),
-    )
-
-    upload_worker_timeout: HumanTimedelta = Field(
-        timedelta(minutes=15),
-        title="Timeout for starting a query with table uploads",
-        description=(
-            "Maximum time allowed to upload tables and submit the query to"
-            " the backend"
-        ),
-    )
-
     @property
     def arq_redis_settings(self) -> RedisSettings:
         """Redis settings for arq."""
@@ -443,6 +436,21 @@ class Config(BaseSettings):
             )
         else:
             return USE_CLIENT_DEFAULT
+
+    @property
+    def api_worker_timeout(self) -> timedelta:
+        """Backend API timeout plus a grace period for arq workers."""
+        return self.backend_api_timeout + ARQ_TIMEOUT_GRACE
+
+    @property
+    def result_worker_timeout(self) -> timedelta:
+        """Result timeout plus a grace period for arq workers."""
+        return self.result_timeout + ARQ_TIMEOUT_GRACE
+
+    @property
+    def upload_worker_timeout(self) -> timedelta:
+        """Qserv upload timeout plus a grace period for arq workers."""
+        return self.qserv_upload_timeout + ARQ_TIMEOUT_GRACE
 
     @field_validator("qserv_database_url")
     @classmethod

--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -122,8 +122,8 @@ class ProcessContext(metaclass=ABCMeta):
         redis_client = cls._create_redis_client()
 
         # Create the arq queues.
-        arq_queue_fast = await cls._create_arq_queue(config.arq_queue_fast)
-        arq_queue_slow = await cls._create_arq_queue(config.arq_queue_slow)
+        arq_queue_fast = await cls._create_arq_queue(config.arq_fast_queue)
+        arq_queue_slow = await cls._create_arq_queue(config.arq_slow_queue)
 
         # Create a Kafka broker used for background tasks. This needs to be a
         # separate broker from the one used by handlers, since the one used by
@@ -304,7 +304,7 @@ class QservProcessContext(ProcessContext):
         cls,
         kafka_broker: KafkaBroker | None = None,
         *,
-        qserv_database_pool_size: int | None = None,
+        worker_max_jobs: int | None = None,
     ) -> Self:
         """Create a new process context from a database engine.
 
@@ -312,10 +312,10 @@ class QservProcessContext(ProcessContext):
         ----------
         kafka_broker
             If not `None`, use this Kafka broker instead of making a new one.
-        qserv_database_pool_size
-            If not `None`, override the default database pool size. This is
-            used by result workers, since they only need one connection per
-            worker job.
+        worker_max_jobs
+            If not `None`, this process context is being created for an arq
+            worker with the given number of maximum simultaneous jobs. This
+            is used to size such settings as the database pool size.
 
         Returns
         -------
@@ -342,7 +342,10 @@ class QservProcessContext(ProcessContext):
         )
 
         # Create the database engine and sessionmaker.
-        pool_size = qserv_database_pool_size or config.qserv_database_pool_size
+        if worker_max_jobs:
+            pool_size = min(config.qserv_database_pool_size, worker_max_jobs)
+        else:
+            pool_size = config.qserv_database_pool_size
         connect_args = {
             "ssl": ssl_context,
             "connect_timeout": config.qserv_database_connect_timeout,
@@ -401,7 +404,7 @@ async def build_process_context(
         case BackendType.QSERV:
             if worker_max_jobs is not None:
                 return await QservProcessContext.create(
-                    kafka_broker, qserv_database_pool_size=worker_max_jobs
+                    kafka_broker, worker_max_jobs=worker_max_jobs
                 )
             else:
                 return await QservProcessContext.create(kafka_broker)

--- a/src/qservkafka/periodic_metrics.py
+++ b/src/qservkafka/periodic_metrics.py
@@ -15,7 +15,7 @@ async def publish_arq_metrics() -> None:
         arq_events = ArqEvents()
         settings = config.arq_redis_settings
         await arq_events.initialize(manager)
-        await publish_queue_stats(config.arq_queue_slow, settings, arq_events)
-        await publish_queue_stats(config.arq_queue_fast, settings, arq_events)
+        await publish_queue_stats(config.arq_slow_queue, settings, arq_events)
+        await publish_queue_stats(config.arq_fast_queue, settings, arq_events)
     finally:
         await manager.aclose()

--- a/src/qservkafka/workers/main.py
+++ b/src/qservkafka/workers/main.py
@@ -14,11 +14,12 @@ from structlog.stdlib import get_logger
 
 from .. import __version__
 from ..config import config
-from ..constants import ARQ_TIMEOUT_GRACE
 from ..factory import ProcessContext, build_process_context
 from .functions.cleanup import cleanup_query
 from .functions.results import finish_query
 from .functions.upload import start_query
+
+__all__ = ["FastWorkerSettings", "SlowWorkerSettings"]
 
 
 async def startup(ctx: dict[Any, Any]) -> None:
@@ -74,48 +75,39 @@ async def shutdown(ctx: dict[Any, Any]) -> None:
     await context.aclose()
 
 
-class WorkerSettings:
-    """Configuration for the arq worker that processes completed queries."""
+class FastWorkerSettings:
+    """Configuration for the arq worker for I/O-intensive jobs.
 
-    functions: ClassVar[list[Callable]] = [finish_query]
-    queue_name = config.arq_queue_slow
-    redis_settings = config.arq_redis_settings
-    on_startup = startup
-    on_shutdown = shutdown
-    on_job_start = make_on_job_start(config.arq_queue_slow)
-    job_completion_wait = int(
-        (config.result_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
-    )
-    max_jobs = config.max_worker_jobs
-    job_timeout = config.result_timeout + ARQ_TIMEOUT_GRACE
-    ctx: ClassVar[dict[str, int]] = {"max_jobs": config.max_worker_jobs}
-
-
-class UploadWorkerSettings:
-    """Configuration for the arq worker that starts queries with uploads.
-
-    Runs on a separate queue from `WorkerSettings` so that a slow upload
-    can't starve result processing.
+    Runs on a separate queue so that a slow result upload can't starve user
+    table uploads or cleanup jobs.
     """
 
     functions: ClassVar[list[Callable | Function]] = [
-        func(
-            cleanup_query,
-            timeout=config.upload_worker_timeout + ARQ_TIMEOUT_GRACE,
-        ),
+        func(cleanup_query, timeout=config.api_worker_timeout),
         finish_query,
-        func(
-            start_query,
-            timeout=config.upload_worker_timeout + ARQ_TIMEOUT_GRACE,
-        ),
+        func(start_query, timeout=config.upload_worker_timeout),
     ]
-    queue_name = config.arq_queue_fast
+    queue_name = config.arq_fast_queue
     redis_settings = config.arq_redis_settings
     on_startup = startup
     on_shutdown = shutdown
-    on_job_start = make_on_job_start(config.arq_queue_fast)
-    job_completion_wait = int(
-        (config.result_timeout + ARQ_TIMEOUT_GRACE).total_seconds()
-    )
-    max_jobs = config.upload_worker_max_jobs
-    ctx: ClassVar[dict[str, int]] = {"max_jobs": config.upload_worker_max_jobs}
+    on_job_start = make_on_job_start(config.arq_fast_queue)
+    job_completion_wait = int(config.result_worker_timeout.total_seconds())
+    max_jobs = config.arq_fast_max_jobs
+    job_timeout = config.result_worker_timeout
+    ctx: ClassVar[dict[str, int]] = {"max_jobs": config.arq_fast_max_jobs}
+
+
+class SlowWorkerSettings:
+    """Configuration for the arq worker for CPU-intensive jobs."""
+
+    functions: ClassVar[list[Callable]] = [finish_query]
+    queue_name = config.arq_slow_queue
+    redis_settings = config.arq_redis_settings
+    on_startup = startup
+    on_shutdown = shutdown
+    on_job_start = make_on_job_start(config.arq_slow_queue)
+    job_completion_wait = int(config.result_worker_timeout.total_seconds())
+    max_jobs = config.arq_slow_max_jobs
+    job_timeout = config.result_worker_timeout
+    ctx: ClassVar[dict[str, int]] = {"max_jobs": config.arq_slow_max_jobs}

--- a/tests/support/arq.py
+++ b/tests/support/arq.py
@@ -11,7 +11,7 @@ from safir.metrics.arq import initialize_arq_metrics
 
 from qservkafka.config import config
 from qservkafka.factory import ProcessContext
-from qservkafka.workers.main import UploadWorkerSettings, WorkerSettings
+from qservkafka.workers.main import FastWorkerSettings, SlowWorkerSettings
 
 __all__ = ["ArqWorkers"]
 
@@ -28,8 +28,8 @@ class ArqWorkers:
     def __init__(self, context: ProcessContext) -> None:
         self._context = context
         self._metrics_initialized = False
-        self._fast_worker = self._create_worker(UploadWorkerSettings)
-        self._slow_worker = self._create_worker(WorkerSettings)
+        self._fast_worker = self._create_worker(FastWorkerSettings)
+        self._slow_worker = self._create_worker(SlowWorkerSettings)
 
         self._fast_count = 0
         self._slow_count = 0
@@ -100,7 +100,7 @@ class ArqWorkers:
                     return count
                 await asyncio.sleep(0.01)
 
-    def _create_worker(self, settings: type[Any] = WorkerSettings) -> Worker:
+    def _create_worker(self, settings: type[Any]) -> Worker:
         """Create an arq worker to run queued jobs.
 
         Parameters


### PR DESCRIPTION
Finish the renaming of the arq queues to fast and slow, and update the configuration settings accordingly. Move more of the logic for calculating the worker settings into the `Config` class.