### PR TITLE
DM-55758: Fix initialization of BigQuery process context

### DIFF
--- a/src/qservkafka/factory.py
+++ b/src/qservkafka/factory.py
@@ -400,7 +400,7 @@ async def build_process_context(
     """
     match config.backend:
         case BackendType.BIGQUERY:
-            return await ProcessContext.create(kafka_broker)
+            return await BigQueryProcessContext.create(kafka_broker)
         case BackendType.QSERV:
             if worker_max_jobs is not None:
                 return await QservProcessContext.create(


### PR DESCRIPTION
The factory function to create a process context for BigQuery must use the specialized process context, not the generic one.