### PR TITLE
DM-55660: Cancel queries in the backend once they exceed the maximum timeout set for the job

### DIFF
--- a/changelog.d/20260826_142534_steliosvoutsinas_DM_55660.md
+++ b/changelog.d/20260826_142534_steliosvoutsinas_DM_55660.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Cancel queries in the backend (Qserv or BigQuery) once they exceed the maximum execution duration requested by the TAP server.

--- a/src/qservkafka/models/state.py
+++ b/src/qservkafka/models/state.py
@@ -98,6 +98,17 @@ class RunningQuery(StartedQuery):
         bool, Field(title="Whether queued for result procesing")
     ]
 
+    cancel_requested: Annotated[
+        bool,
+        Field(
+            title="Whether cancellation was requested",
+            description=(
+                "Set once the bridge has asked the backend to cancel this"
+                " query because it exceeded its maximum execution duration."
+            ),
+        ),
+    ] = False
+
     @classmethod
     def from_started_query(
         cls, query: StartedQuery, status: QueryStatus
@@ -116,6 +127,9 @@ class RunningQuery(StartedQuery):
         Query
             Query state.
         """
+        cancel_requested = False
+        if isinstance(query, RunningQuery):
+            cancel_requested = query.cancel_requested
         return cls(
             query_id=query.query_id,
             queued=query.queued,
@@ -124,6 +138,7 @@ class RunningQuery(StartedQuery):
             job=query.job,
             status=status,
             result_queued=False,
+            cancel_requested=cancel_requested,
         )
 
     @override

--- a/src/qservkafka/services/monitor.py
+++ b/src/qservkafka/services/monitor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections import Counter
+from datetime import UTC, datetime, timedelta
 
 from safir.arq import ArqQueue
 from structlog.stdlib import BoundLogger
@@ -119,6 +120,12 @@ class QueryMonitor:
             logger.debug("Skipping already queued query")
             return
 
+        exceeded_timeout = self._exceeded_timeout(query)
+        if not query.cancel_requested and exceeded_timeout is not None:
+            await self._query.cancel_timed_out_query(query, exceeded_timeout)
+            query.cancel_requested = True
+            await self._state.mark_cancel_requested(query.query_id)
+
         # Send updates to executing queries directly from the background
         # monitoring task for faster updates, but dispatch any completed
         # queries to a result worker.
@@ -145,6 +152,28 @@ class QueryMonitor:
             await self._arq_slow.enqueue("finish_query", query.query_id)
             await self._state.mark_queued_query(query.query_id)
             logger.info("Dispatched finished query to worker")
+
+    def _exceeded_timeout(self, query: RunningQuery) -> timedelta | None:
+        """Return the timeout a query has exceeded (if any).
+
+        Parameters
+        ----------
+        query
+            Running query to check.
+
+        Returns
+        -------
+        timedelta or None
+            The configured maximum execution duration, if the query has run
+            longer than it and should be cancelled. `None` if the
+            query has no configured timeout, or has not yet exceeded it.
+        """
+        timeout = query.job.timeout
+        if timeout is None:
+            return None
+        if datetime.now(tz=UTC) - query.created > timeout:
+            return timeout
+        return None
 
     async def reconcile_rate_limits(self) -> None:
         """Reconcile rate limits against currently running queries."""

--- a/src/qservkafka/services/query.py
+++ b/src/qservkafka/services/query.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from safir.arq import ArqQueue
 from safir.sentry import report_exception
@@ -110,7 +110,43 @@ class QueryService:
         if not query:
             logger.info("Ignoring cancel of unknown or completed job")
             return
+        await self._cancel_backend_query(query_id, query.job.owner, logger)
 
+    async def cancel_timed_out_query(
+        self, query: RunningQuery, timeout: timedelta
+    ) -> None:
+        """Cancel a query that exceeded its maximum execution duration.
+
+        Parameters
+        ----------
+        query
+            Running query that has exceeded its configured timeout.
+        timeout
+            The maximum execution duration that was exceeded.
+        """
+        logger = self._logger.bind(**query.to_logging_context())
+        logger.info(
+            "Cancelling query that exceeded maximum execution duration",
+            timeout=timeout.total_seconds(),
+        )
+        await self._cancel_backend_query(
+            query.query_id, query.job.owner, logger
+        )
+
+    async def _cancel_backend_query(
+        self, query_id: str, owner: str, logger: BoundLogger
+    ) -> None:
+        """Ask the backend to cancel a query, tolerating benign races.
+
+        Parameters
+        ----------
+        query_id
+            ID of the query to cancel.
+        owner
+            Username of the query owner, for error reporting.
+        logger
+            Logger to use.
+        """
         # Cancel the query. If this fails, check to see if it only failed
         # because the job finished and, if so, quietly do nothing. Otherwise,
         # log an exception, which is the best we can do since we don't have a
@@ -118,7 +154,7 @@ class QueryService:
         try:
             await self._backend.cancel_query(query_id)
         except BackendApiError as e:
-            e.user = cancel.owner
+            e.user = owner
             try:
                 status = await self._backend.get_query_status(query_id)
                 if status.status != AsyncQueryPhase.EXECUTING:

--- a/src/qservkafka/storage/state.py
+++ b/src/qservkafka/storage/state.py
@@ -70,6 +70,19 @@ class QueryStateStore:
         """
         return await self._storage.get(query_id)
 
+    async def mark_cancel_requested(self, query_id: str) -> None:
+        """Mark a query as having had cancellation requested.
+
+        Parameters
+        ----------
+        query_id
+            Backend query ID.
+        """
+        query = await self.get_query(query_id)
+        if query:
+            query.cancel_requested = True
+            await self.store_query(query)
+
     async def mark_queued_query(self, query_id: str) -> None:
         """Mark a query as queued.
 

--- a/tests/data/jobs/timeout.json
+++ b/tests/data/jobs/timeout.json
@@ -1,0 +1,26 @@
+{
+  "query": "SELECT TOP 10 * FROM table",
+  "database": "dp1",
+  "jobID": "uws123",
+  "ownerID": "username",
+  "resultDestination": "https://gcs.example.com/upload",
+  "timeout": 60,
+  "resultFormat": {
+    "format": {
+      "type": "VOTable",
+      "serialization": "BINARY2"
+    },
+    "envelope": {
+      "header": "<VOTable xmlns=\"http://www.ivoa.net/xml/VOTable/v1.3\" version=\"1.3\"><RESOURCE type=\"results\"><TABLE><FIELD ID=\"col_0\" arraysize=\"*\" datatype=\"char\" name=\"col1\"/>",
+      "footer": "</TABLE></RESOURCE></VOTable>",
+      "footerOverflow": "</TABLE><INFO name=\"QUERY_STATUS\" value=\"OVERFLOW\"/></RESOURCE></VOTABLE>"
+    },
+    "columnTypes": [
+      {
+        "name": "col_0",
+        "datatype": "char",
+        "arraysize": "*"
+      }
+    ]
+  }
+}

--- a/tests/services/monitor_test.py
+++ b/tests/services/monitor_test.py
@@ -1,19 +1,33 @@
 """Tests for the query status monitor."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import call, patch
 
 import pytest
+import respx
 from safir.arq import RedisArqQueue
 from safir.metrics import MockEventPublisher
 from testcontainers.redis import RedisContainer
 
 from qservkafka.factory import Factory
 from qservkafka.models.kafka import JobRun
+from qservkafka.models.qserv import QservQueryPhase
 
 from ..support.data import QservKafkaData
 from ..support.kafka import read_status_message
 from ..support.qserv import MockQserv
+
+
+def _cancel_call_count(respx_mock: respx.Router, query_id: int) -> int:
+    """Count how many times a query was cancelled in the backend."""
+    return len(
+        [
+            c
+            for c in respx_mock.calls
+            if c.request.method == "DELETE"
+            and c.request.url.path.endswith(f"/query-async/{query_id}")
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -119,3 +133,42 @@ async def test_quota(
     redis_client.set("rate:other-user", b"1")
     await monitor.reconcile_rate_limits()
     assert redis_client.get("rate:other-user") is None
+
+
+@pytest.mark.asyncio
+async def test_execution_timeout(
+    *,
+    data: QservKafkaData,
+    factory: Factory,
+    mock_qserv: MockQserv,
+    respx_mock: respx.Router,
+) -> None:
+    query_service = factory.create_query_service()
+    state_store = factory.create_query_state_store()
+    monitor = await factory.create_query_monitor()
+    job = data.read_pydantic(JobRun, "jobs/timeout")
+
+    await query_service.handle_query(job)
+    read_status_message(factory)
+
+    await monitor.check_status()
+    assert mock_qserv.get_status(1).status == QservQueryPhase.EXECUTING
+    assert _cancel_call_count(respx_mock, 1) == 0
+
+    query = await state_store.get_query(str(1))
+    assert query
+    # Make query appear to have exceeded timeout of 60s
+    query.created -= timedelta(seconds=100)
+    await state_store.store_query(query)
+
+    # This should cause the query to be cancelled
+    await monitor.check_status()
+    assert mock_qserv.get_status(1).status == QservQueryPhase.ABORTED
+    assert _cancel_call_count(respx_mock, 1) == 1
+    query = await state_store.get_query(str(1))
+    assert query
+    assert query.cancel_requested is True
+
+    # Make sure we're only requesting cancellation once
+    await monitor.check_status()
+    assert _cancel_call_count(respx_mock, 1) == 1


### PR DESCRIPTION
The problem this PR is addressing, is that queries that exceed the provided timeout continue running past it, which is invalid according to the TAP standard.

The fix here adds a `cancel_requested` flag to the `RunningQuery` model and then during checks we check if the duration has exceeded the provided `timeout` and if so set the `cancel_requested` flag to `true` and request cancellation from the backend. The reason for the flag is to ensure we only request cancellation once across multiple checks.